### PR TITLE
NET-1368: Command dispatch

### DIFF
--- a/src/Commands/Command.cs
+++ b/src/Commands/Command.cs
@@ -1,0 +1,22 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Defines a command that returns a result when executed.
+    /// </summary>
+    /// <typeparam name="TResult">Type of the command result.</typeparam>
+
+    public abstract record Command<TResult> { }
+
+    /// <summary>
+    /// Defines a command that does not return a result when executed.
+    /// </summary>
+
+    public abstract record Command : Command<ValueTuple> { }
+}

--- a/src/Commands/CommandHandler.cs
+++ b/src/Commands/CommandHandler.cs
@@ -1,0 +1,76 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Defines a handler for a command type that returns a result.
+    /// </summary>
+    /// <typeparam name="TCommand">Type of the command.</typeparam>
+    /// <typeparam name="TResult">Type of the command result.</typeparam>
+
+    public abstract class CommandHandler<TCommand, TResult> : ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+    {
+        /// <summary>
+        /// Executes the logic for the given command.
+        /// The command argument will be non-null at this point.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the command's execution.</returns>
+
+        protected abstract Task<TResult> Execute( TCommand command, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Explicit interface definition.
+        /// This will null-check the command argument and await the specific implementation.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the command's execution.</returns>
+
+        async Task<TResult> ICommandHandler<TCommand, TResult>.Execute( TCommand command, CancellationToken cancellationToken )
+        {
+            return command == null ? throw new ArgumentNullException( nameof( command ) ) : await Execute( command, cancellationToken );
+        }
+    }
+
+    /// <summary>
+    /// Defines a handler for a command type that does not return a result.
+    /// </summary>
+    /// <typeparam name="TCommand">Type of the command.</typeparam>
+
+    public abstract class CommandHandler<TCommand> : ICommandHandler<TCommand, ValueTuple> where TCommand : Command
+    {
+        /// <summary>
+        /// Executes the logic for the given command.
+        /// The command argument will be non-null at this point.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+
+        protected abstract Task Execute( TCommand command, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Explicit interface definition.
+        /// This will null-check the command argument and await the specific implementation.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A unit type that represents no result.</returns>
+
+        async Task<ValueTuple> ICommandHandler<TCommand, ValueTuple>.Execute( TCommand command, CancellationToken cancellationToken )
+        {
+            if ( command == null ) throw new ArgumentNullException( nameof( command ) );
+
+            await Execute( command, cancellationToken );
+            return default;
+        }
+    }
+}

--- a/src/Commands/ICommandDispatcher.cs
+++ b/src/Commands/ICommandDispatcher.cs
@@ -1,0 +1,37 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Defines a dispatcher for locating and executing the handlers of commands.
+    /// </summary>
+
+    public interface ICommandDispatcher
+    {
+        /// <summary>
+        /// Locates and awaits execution of the handler for the given command.
+        /// </summary>
+        /// <typeparam name="TResult">Type of the command result.</typeparam>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of command execution.</returns>
+
+        Task<TResult> Execute<TResult>( Command<TResult> command, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Locates and awaits execution of the handler for the given command.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+
+        async Task Execute( Command command, CancellationToken cancellationToken ) =>
+            await Execute<ValueTuple>( command, cancellationToken );
+    }
+}

--- a/src/Commands/ICommandHandler.cs
+++ b/src/Commands/ICommandHandler.cs
@@ -1,0 +1,29 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Defines a handler for executing a command.
+    /// Use one of the available abstract handlers to implement this interface.
+    /// </summary>
+    /// <typeparam name="TCommand">Type of the command.</typeparam>
+    /// <typeparam name="TResult">Type of the command result.</typeparam>
+
+    public interface ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+    {
+        /// <summary>
+        /// Executes the given command.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the command's execution.</returns>
+
+        Task<TResult> Execute( TCommand command, CancellationToken cancellationToken );
+    }
+}

--- a/src/Commands/Internal/CancellationDecorator.cs
+++ b/src/Commands/Internal/CancellationDecorator.cs
@@ -1,0 +1,46 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands.Internal
+{
+    /// <summary>
+    /// Decorates a command handler to add pre-execution cancellation support.
+    /// </summary>
+    /// <typeparam name="TCommand">Type of the command.</typeparam>
+    /// <typeparam name="TResult">Type of the command result.</typeparam>
+
+    public class CancellationDecorator<TCommand, TResult> : CommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+    {
+        private readonly ICommandHandler<TCommand, TResult> inner;
+
+        /// <summary>
+        /// Decorates a command handler to add pre-execution cancellation support.
+        /// </summary>
+        /// <param name="inner">Command handler to decorate.</param>
+
+        public CancellationDecorator( ICommandHandler<TCommand, TResult> inner )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if cancellation has been requested.
+        /// Otherwise awaits execution of the decorated handler.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of command execution.</returns>
+
+        protected override async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await inner.Execute( command, cancellationToken );
+        }
+    }
+}

--- a/src/Commands/Internal/CommandDispatcher.cs
+++ b/src/Commands/Internal/CommandDispatcher.cs
@@ -1,0 +1,56 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands.Internal
+{
+    /// <summary>
+    /// Dispatcher for locating and executing the handlers of commands.
+    /// </summary>
+
+    public class CommandDispatcher : ICommandDispatcher
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Constructs a dispatcher for locating and executing the handlers of commands.
+        /// </summary>
+        /// <param name="serviceProvider">Dependency injection container or service provider.</param>
+        /// <exception cref="ArgumentNullException">serviceProvider is null.</exception>
+
+        public CommandDispatcher( IServiceProvider serviceProvider )
+        {
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException( nameof( serviceProvider ) );
+        }
+
+        /// <summary>
+        /// Locates and awaits execution of the handler for the given command.
+        /// </summary>
+        /// <typeparam name="TResult">Type of the command result.</typeparam>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of command execution.</returns>
+
+        public async Task<TResult> Execute<TResult>( Command<TResult> command, CancellationToken cancellationToken )
+        {
+            if ( command == null ) throw new ArgumentNullException( nameof( command ) );
+
+            var commandType = command.GetType();
+            var resultType = typeof( TResult );
+            var handlerType = typeof( ICommandHandler<,> ).MakeGenericType( commandType, resultType );
+
+            dynamic handler = serviceProvider.GetService( handlerType ) ??
+                throw new InvalidOperationException( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, handlerType ) );
+
+            // use of the dynamic type offloads the complex reflection, expression tree caching,
+            // and delegate compilation to the DLR. this results in reflection overhead only applying
+            // to the first call; subsequent calls perform similar to statically-compiled statements.
+            return await handler.Execute( (dynamic)command, cancellationToken );
+        }
+    }
+}

--- a/src/Commands/Internal/ValidationDecorator.cs
+++ b/src/Commands/Internal/ValidationDecorator.cs
@@ -1,0 +1,50 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Validation;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Commands.Internal
+{
+    /// <summary>
+    /// Decorates a command handler to add pre-execution validation support.
+    /// </summary>
+    /// <typeparam name="TCommand">Type of the command.</typeparam>
+    /// <typeparam name="TResult">Type of the command result.</typeparam>
+
+    public class ValidationDecorator<TCommand, TResult> : CommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+    {
+        private readonly ICommandHandler<TCommand, TResult> inner;
+        private readonly IValidationAdapter<TCommand> validator;
+
+        /// <summary>
+        /// Decorates a command handler to add pre-execution validation support.
+        /// </summary>
+        /// <param name="inner">Command handler to decorate.</param>
+        /// <param name="validator">Validation adapter for the command type.</param>
+
+        public ValidationDecorator( ICommandHandler<TCommand, TResult> inner, IValidationAdapter<TCommand> validator )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+            this.validator = validator ?? throw new ArgumentNullException( nameof( validator ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if validation of the command fails.
+        /// Otherwise awaits execution of the decorated handler.
+        /// </summary>
+        /// <param name="command">Command to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of command execution.</returns>
+
+        protected override async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+        {
+            await validator.ValidateAndThrow( command, cancellationToken );
+            return await inner.Execute( command, cancellationToken );
+        }
+    }
+}

--- a/src/Resources/CoreErrorMessages.Designer.cs
+++ b/src/Resources/CoreErrorMessages.Designer.cs
@@ -61,11 +61,11 @@ namespace Shipwright.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find a required implementation of IValidator&lt;{0}&gt;.
+        ///   Looks up a localized string similar to Unable to find a required implementation of the type {0}.
         /// </summary>
-        public static string MissingRequiredValidator {
+        public static string MissingRequiredImplementation {
             get {
-                return ResourceManager.GetString("MissingRequiredValidator", resourceCulture);
+                return ResourceManager.GetString("MissingRequiredImplementation", resourceCulture);
             }
         }
     }

--- a/src/Resources/CoreErrorMessages.resx
+++ b/src/Resources/CoreErrorMessages.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="MissingRequiredValidator" xml:space="preserve">
-    <value>Unable to find a required implementation of IValidator&lt;{0}&gt;</value>
+  <data name="MissingRequiredImplementation" xml:space="preserve">
+    <value>Unable to find a required implementation of the type {0}</value>
   </data>
 </root>

--- a/src/Validation/ValidationAdapter.cs
+++ b/src/Validation/ValidationAdapter.cs
@@ -46,7 +46,7 @@ namespace Shipwright.Validation
 
             if ( instance is IRequiresValidation && !validators.Any() )
             {
-                throw new InvalidOperationException( string.Format( Resources.CoreErrorMessages.MissingRequiredValidator, typeof( T ) ) );
+                throw new InvalidOperationException( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, typeof( IValidator<T> ) ) );
             }
 
             var errors = new List<ValidationFailure>();

--- a/test/Commands/FakeGuidCommand.cs
+++ b/test/Commands/FakeGuidCommand.cs
@@ -1,0 +1,18 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Fake command for testing.
+    /// </summary>
+
+    public record FakeGuidCommand : Command<Guid>
+    {
+        public Guid Value { get; init; } = Guid.NewGuid();
+    }
+}

--- a/test/Commands/FakeVoidCommand.cs
+++ b/test/Commands/FakeVoidCommand.cs
@@ -1,0 +1,18 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+
+namespace Shipwright.Commands
+{
+    /// <summary>
+    /// Fake command for testing.
+    /// </summary>
+
+    public record FakeVoidCommand : Command
+    {
+        public Guid Value { get; init; } = Guid.NewGuid();
+    }
+}

--- a/test/Commands/Internal/CancellationDecoratorTests.cs
+++ b/test/Commands/Internal/CancellationDecoratorTests.cs
@@ -1,0 +1,68 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Commands.Internal
+{
+    public class CancellationDecoratorTests
+    {
+        private ICommandHandler<FakeGuidCommand, Guid> inner;
+        private ICommandHandler<FakeGuidCommand, Guid> instance() => new CancellationDecorator<FakeGuidCommand, Guid>( inner );
+        private readonly Mock<ICommandHandler<FakeGuidCommand, Guid>> mockInner;
+
+        public CancellationDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+        }
+
+        public class Constructor : CancellationDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+        }
+
+        public class Execute : CancellationDecoratorTests
+        {
+            private FakeGuidCommand command = new FakeGuidCommand();
+            private CancellationToken cancellationToken;
+            private Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+            [Fact]
+            public async Task requires_command()
+            {
+                command = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( command ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_canceled()
+            {
+                cancellationToken = new CancellationToken( true );
+                await Assert.ThrowsAsync<OperationCanceledException>( method );
+            }
+
+            [Fact]
+            public async Task awaits_inner_handler_when_not_canceled()
+            {
+                cancellationToken = new CancellationToken( false );
+
+                var expected = Guid.NewGuid();
+                mockInner.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Equal( expected, actual );
+            }
+        }
+    }
+}

--- a/test/Commands/Internal/CommandDispatcherTests.cs
+++ b/test/Commands/Internal/CommandDispatcherTests.cs
@@ -1,0 +1,114 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Commands.Internal
+{
+    public class CommandDispatcherTests
+    {
+        private IServiceProvider serviceProvider;
+        private ICommandDispatcher instance() => new CommandDispatcher( serviceProvider );
+
+        private readonly Mock<IServiceProvider> mockServiceProvider;
+
+        public CommandDispatcherTests()
+        {
+            mockServiceProvider = Mockery.Of( out serviceProvider );
+        }
+
+        public class Constructor : CommandDispatcherTests
+        {
+            [Fact]
+            public void requires_serviceProvider()
+            {
+                serviceProvider = null!;
+                Assert.Throws<ArgumentNullException>( nameof( serviceProvider ), instance );
+            }
+        }
+
+        public class Execute_Returning : CommandDispatcherTests
+        {
+            private Command<Guid> command = new FakeGuidCommand();
+            private CancellationToken cancellationToken;
+            private Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+            [Fact]
+            public async Task requires_command()
+            {
+                command = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( command ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_no_handler_found()
+            {
+                var handlerType = typeof( ICommandHandler<FakeGuidCommand, Guid> );
+                mockServiceProvider.Setup( _ => _.GetService( handlerType ) ).Returns( null );
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>( method );
+                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, handlerType ), ex.Message );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_awaited_result_from_inner_handler( bool canceled )
+            {
+                var expected = Guid.NewGuid();
+                cancellationToken = new CancellationToken( canceled );
+                var handlerType = typeof( ICommandHandler<FakeGuidCommand, Guid> );
+                var mockHandler = Mockery.Of( out ICommandHandler<FakeGuidCommand, Guid> handler );
+                mockServiceProvider.Setup( _ => _.GetService( handlerType ) ).Returns( handler );
+                mockHandler.Setup( _ => _.Execute( (FakeGuidCommand)command, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Equal( expected, actual );
+            }
+        }
+
+        public class Execute_Void : CommandDispatcherTests
+        {
+            private Command command = new FakeVoidCommand();
+            private CancellationToken cancellationToken;
+
+            private Task method() => instance().Execute( command, cancellationToken );
+
+            [Fact]
+            public async Task requires_command()
+            {
+                command = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( command ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_no_handler_found()
+            {
+                var handlerType = typeof( ICommandHandler<FakeVoidCommand, ValueTuple> );
+                mockServiceProvider.Setup( _ => _.GetService( handlerType ) ).Returns( null );
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>( method );
+                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, handlerType ), ex.Message );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_awaited_result_from_inner_handler( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+                var handlerType = typeof( ICommandHandler<FakeVoidCommand, ValueTuple> );
+                var mockHandler = Mockery.Of( out ICommandHandler<FakeVoidCommand, ValueTuple> handler );
+                mockServiceProvider.Setup( _ => _.GetService( handlerType ) ).Returns( handler );
+                mockHandler.Setup( _ => _.Execute( (FakeVoidCommand)command, cancellationToken ) ).ReturnsAsync( default( ValueTuple ) );
+
+                await method();
+                mockHandler.Verify( _ => _.Execute( (FakeVoidCommand)command, cancellationToken ), Times.Once() );
+            }
+        }
+    }
+}

--- a/test/Commands/Internal/ValidationDecoratorTests.cs
+++ b/test/Commands/Internal/ValidationDecoratorTests.cs
@@ -1,0 +1,88 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using Moq;
+using Shipwright.Validation;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Commands.Internal
+{
+    public class ValidationDecoratorTests
+    {
+        private ICommandHandler<FakeGuidCommand, Guid> inner;
+        private IValidationAdapter<FakeGuidCommand> validator;
+        private ICommandHandler<FakeGuidCommand, Guid> instance() => new ValidationDecorator<FakeGuidCommand, Guid>( inner, validator );
+        private readonly Mock<ICommandHandler<FakeGuidCommand, Guid>> mockInner;
+        private readonly Mock<IValidationAdapter<FakeGuidCommand>> mockValidator;
+
+        public ValidationDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+            mockValidator = Mockery.Of( out validator );
+        }
+
+        public class Constructor : ValidationDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+
+            [Fact]
+            public void requires_validator()
+            {
+                validator = null!;
+                Assert.Throws<ArgumentNullException>( nameof( validator ), instance );
+            }
+        }
+
+        public class Execute : ValidationDecoratorTests
+        {
+            private FakeGuidCommand command = new FakeGuidCommand();
+            private CancellationToken cancellationToken;
+            private Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+            [Fact]
+            public async Task requires_command()
+            {
+                command = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( command ), method );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task rethrows_when_validation_fails( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+                var expected = new ValidationException( Guid.NewGuid().ToString() );
+                mockValidator.Setup( _ => _.ValidateAndThrow( command, cancellationToken ) ).ThrowsAsync( expected );
+                var actual = await Assert.ThrowsAsync<ValidationException>( method );
+                Assert.Equal( expected, actual );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task awaits_inner_handler_when_validation_passes( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var expected = Guid.NewGuid();
+                mockValidator.Setup( _ => _.ValidateAndThrow( command, cancellationToken ) ).Returns( Task.CompletedTask );
+                mockInner.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Equal( expected, actual );
+
+                mockValidator.Verify( _ => _.ValidateAndThrow( command, cancellationToken ), Times.Once() );
+            }
+        }
+    }
+}

--- a/test/Validation/ValidationAdapterTests.cs
+++ b/test/Validation/ValidationAdapterTests.cs
@@ -143,7 +143,7 @@ namespace Shipwright.Validation
                 cancellationToken = new CancellationToken( canceled );
                 context.validators.Clear();
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>( method );
-                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredValidator, typeof( ValidationRequired ) ), ex.Message );
+                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, typeof( IValidator<ValidationRequired> ) ), ex.Message );
             }
         }
 
@@ -245,7 +245,7 @@ namespace Shipwright.Validation
                 cancellationToken = new CancellationToken( canceled );
                 context.validators.Clear();
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>( method );
-                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredValidator, typeof( ValidationRequired ) ), ex.Message );
+                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, typeof( IValidator<ValidationRequired> ) ), ex.Message );
             }
         }
     }


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1368
---
### Problem
As a developer, I want to use a command pattern for executing complex serializable actions so that:
- Execution can be handed off to other processes.
- Cross-cutting concerns like validation and cancellation can be handled outside of command logic.

### Solution
- Added a dispatch mechanism that allows a serializable command to be declared independently of its execution.
- Defined abstractions for implementing command logic.
- Applied validation and cancellation logic using the decorator pattern.

### Additional Notes
Requires use of dependency injection or inversion-of-control container that allows for declarative decoration.