### PR TITLE
NET-1420: Dataflow record sources

### DIFF
--- a/lamar/src/Dataflows/LamarDataflowSourceExtensions.cs
+++ b/lamar/src/Dataflows/LamarDataflowSourceExtensions.cs
@@ -1,0 +1,76 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Lamar;
+using Lamar.Scanning.Conventions;
+using Shipwright.Dataflows.Sources;
+using Shipwright.Dataflows.Sources.Internal;
+using System;
+
+namespace Shipwright.Dataflows
+{
+    /// <summary>
+    /// Extension methods for registering dataflow types with Lamar.
+    /// </summary>
+
+    public static class LamarDataflowSourceExtensions
+    {
+        /// <summary>
+        /// Adds the stock Shipwright dataflow record source dispatcher.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddSourceDispatch( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For<ISourceDispatcher>().Add<SourceDispatcher>();
+            return registry;
+        }
+
+        /// <summary>
+        /// Adds all implementations of <see cref="ISourceHandler{TSource}"/> found in the scanned assemblies.
+        /// </summary>
+        /// <param name="scanner">Lamar assembly scanner.</param>
+        /// <returns>The assembly scanner.</returns>
+
+        public static IAssemblyScanner AddSourceHandlers( this IAssemblyScanner scanner )
+        {
+            if ( scanner == null ) throw new ArgumentNullException( nameof( scanner ) );
+
+            scanner.ConnectImplementationsToTypesClosing( typeof( ISourceHandler<> ) );
+            return scanner;
+        }
+
+        /// <summary>
+        /// Adds the validation decorator to all implementations of <see cref="ISourceHandler{TSource}"/>.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddSourceValidation( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For( typeof( ISourceHandler<> ) ).DecorateAllWith( typeof( ValidationDecorator<> ) );
+            return registry;
+        }
+
+        /// <summary>
+        /// Adds the cancellation decorator to all implementations of <see cref="ISourceHandler{TSource}"/>.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddSourceCancellation( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For( typeof( ISourceHandler<> ) ).DecorateAllWith( typeof( CancellationDecorator<> ) );
+            return registry;
+        }
+    }
+}

--- a/lamar/test/Dataflows/LamarDataflowSourceExtensionsTests.cs
+++ b/lamar/test/Dataflows/LamarDataflowSourceExtensionsTests.cs
@@ -1,0 +1,139 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Lamar;
+using Lamar.Scanning.Conventions;
+using Moq;
+using Shipwright.Dataflows.Sources;
+using Shipwright.Dataflows.Sources.Internal;
+using Shipwright.Validation;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Shipwright.Dataflows
+{
+    public class LamarDataflowSourceExtensionsTests
+    {
+        private ServiceRegistry registry = new ServiceRegistry();
+
+        public class AddSourceDispatch : LamarDataflowSourceExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddSourceDispatch();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void registers_dispatcher()
+            {
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( actual );
+                var instance = container.GetInstance<ISourceDispatcher>();
+                Assert.IsType<SourceDispatcher>( instance );
+            }
+        }
+
+        public class AddSourceHandlers : LamarDataflowSourceExtensionsTests
+        {
+            private IAssemblyScanner scanner;
+            private IAssemblyScanner method() => scanner.AddSourceHandlers();
+
+            public class FakeSourceHandler : SourceHandler<FakeSource>
+            {
+                protected override IAsyncEnumerable<Record> Read( FakeSource source, StringComparer comparer, CancellationToken cancellationToken ) => throw new NotImplementedException();
+            }
+
+            [Fact]
+            public void requires_scanner()
+            {
+                scanner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( scanner ), method );
+            }
+
+            [Fact]
+            public void registers_discovered_handlers()
+            {
+                registry.Scan( scanner =>
+                {
+                    this.scanner = scanner;
+                    scanner.AssemblyContainingType<Source>(); // sanity check to ensure decorators aren't grabbed
+                    scanner.AssemblyContainingType<AddSourceHandlers>();
+
+                    var actual = method();
+                    Assert.Same( this.scanner, actual );
+                } );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<ISourceHandler<FakeSource>>();
+                Assert.IsType<FakeSourceHandler>( instance );
+            }
+        }
+
+        public class AddSourceValidation : LamarDataflowSourceExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddSourceValidation();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void decorates_handler()
+            {
+                var inner = Mockery.Of<ISourceHandler<FakeSource>>();
+                var validator = Mockery.Of<IValidationAdapter<FakeSource>>();
+                registry.For<ISourceHandler<FakeSource>>().Add( inner );
+                registry.For<IValidationAdapter<FakeSource>>().Add( validator );
+
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<ISourceHandler<FakeSource>>();
+                var decorator = Assert.IsType<ValidationDecorator<FakeSource>>( instance );
+                Assert.Same( inner, decorator.inner );
+                Assert.Same( validator, decorator.validator );
+            }
+        }
+
+        public class AddSourceCancellation : LamarDataflowSourceExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddSourceCancellation();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void decorates_handler()
+            {
+                var inner = Mockery.Of<ISourceHandler<FakeSource>>();
+                registry.For<ISourceHandler<FakeSource>>().Add( inner );
+
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<ISourceHandler<FakeSource>>();
+                var decorator = Assert.IsType<CancellationDecorator<FakeSource>>( instance );
+                Assert.Same( inner, decorator.inner );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Record.cs
+++ b/src/Dataflows/Record.cs
@@ -1,0 +1,59 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Dataflows.Sources;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Shipwright.Dataflows
+{
+    /// <summary>
+    /// Represents a data record within a dataflow.
+    /// </summary>
+
+    public record Record
+    {
+        /// <summary>
+        /// Ordinal position of the record within the dataflow.
+        /// </summary>
+
+        public long Position { get; private set; }
+
+        /// <summary>
+        /// Current values of the data in the record.
+        /// </summary>
+
+        public IDictionary<string, object> Data { get; private set; }
+
+        /// <summary>
+        /// Starting values of the data as they were read from the source.
+        /// </summary>
+
+        public IReadOnlyDictionary<string, object> Origin { get; private set; }
+
+        /// <summary>
+        /// Source from which the record was read.
+        /// </summary>
+
+        public Source Source { get; init; }
+
+        /// <summary>
+        /// Constructs an instance to represent the given data within a dataflow.
+        /// </summary>
+        /// <param name="source">Source from which the record was read.</param>
+        /// <param name="data">Current values of the data in the record.</param>
+        /// <param name="position">Ordinal position of the record within the dataflow.</param>
+        /// <param name="comparer">Comparer for record field name.</param>
+
+        public Record( Source source, IDictionary<string, object> data, long position, StringComparer comparer )
+        {
+            Source = source ?? throw new ArgumentNullException( nameof( source ) );
+            Data = data == null ? throw new ArgumentNullException( nameof( data ) ) : new Dictionary<string, object>( data, comparer );
+            Origin = data.ToImmutableDictionary( comparer );
+            Position = position;
+        }
+    }
+}

--- a/src/Dataflows/Sources/ISourceDispatcher.cs
+++ b/src/Dataflows/Sources/ISourceDispatcher.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources
+{
+    /// <summary>
+    /// Defines a dispatcher for delegating execution of a dataflow record source.
+    /// </summary>
+
+    public interface ISourceDispatcher
+    {
+        /// <summary>
+        /// Reads records from the given dataflow source.
+        /// </summary>
+        /// <param name="source">Dataflow record source.</param>
+        /// <param name="comparer">String comparer for record field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of dataflow records.</returns>
+
+        IAsyncEnumerable<Record> Read( Source source, StringComparer comparer, CancellationToken cancellationToken );
+    }
+}

--- a/src/Dataflows/Sources/ISourceHandler.cs
+++ b/src/Dataflows/Sources/ISourceHandler.cs
@@ -1,0 +1,30 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources
+{
+    /// <summary>
+    /// Defines a handler for a dataflow record source.
+    /// Derive from <see cref="SourceHandler{TSource}"/> to implement a handler for a data source.
+    /// </summary>
+    /// <typeparam name="TSource">Type of the dataflow source.</typeparam>
+
+    public interface ISourceHandler<TSource> where TSource : Source
+    {
+        /// <summary>
+        /// Reads records from the given dataflow source.
+        /// </summary>
+        /// <param name="source">Dataflow record source.</param>
+        /// <param name="comparer">String comparer for record field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of dataflow records.</returns>
+
+        IAsyncEnumerable<Record> Read( TSource source, StringComparer comparer, CancellationToken cancellationToken );
+    }
+}

--- a/src/Dataflows/Sources/Internal/CancellationDecorator.cs
+++ b/src/Dataflows/Sources/Internal/CancellationDecorator.cs
@@ -1,0 +1,51 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    /// <summary>
+    /// Decorates a source handler to add cancellation support.
+    /// </summary>
+
+
+    public class CancellationDecorator<TSource> : SourceHandler<TSource> where TSource : Source
+    {
+        internal readonly ISourceHandler<TSource> inner;
+
+        /// <summary>
+        /// Decorates a source handler to add cancellation support.
+        /// </summary>
+        /// <param name="inner">Command handler to decorate.</param>
+
+        public CancellationDecorator( ISourceHandler<TSource> inner )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if cancellation has been requested.
+        /// </summary>
+        /// <param name="source">Dataflow record source.</param>
+        /// <param name="comparer">String comparer for record field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of records.</returns>
+
+        protected override async IAsyncEnumerable<Record> Read( TSource source, StringComparer comparer, [EnumeratorCancellation] CancellationToken cancellationToken )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await foreach ( var record in inner.Read( source, comparer, cancellationToken ) )
+            {
+                yield return record;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Sources/Internal/SourceDispatcher.cs
+++ b/src/Dataflows/Sources/Internal/SourceDispatcher.cs
@@ -1,0 +1,55 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    /// <summary>
+    /// Dispatcher for reading records from dataflow record sources.
+    /// </summary>
+
+    public class SourceDispatcher : ISourceDispatcher
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Constructs a dispatcher for reading records from dataflow record sources.
+        /// </summary>
+        /// <param name="serviceProvider">Dependency injection container or service provider.</param>
+        /// <exception cref="ArgumentNullException">serviceProvider is null.</exception>
+
+        public SourceDispatcher( IServiceProvider serviceProvider )
+        {
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException( nameof( serviceProvider ) );
+        }
+
+        /// <summary>
+        /// Reads records from the given dataflow source.
+        /// </summary>
+        /// <param name="source">Dataflow record source.</param>
+        /// <param name="comparer">String comparer for record field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of dataflow records.</returns>
+
+        public IAsyncEnumerable<Record> Read( Source source, StringComparer comparer, CancellationToken cancellationToken )
+        {
+            if ( source == null ) throw new ArgumentNullException( nameof( source ) );
+
+            var sourceType = source.GetType();
+            var handlerType = typeof( ISourceHandler<> ).MakeGenericType( sourceType );
+
+            dynamic handler = serviceProvider.GetService( handlerType ) ??
+                throw new InvalidOperationException( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, handlerType ) );
+
+            // use of the dynamic type offloads the complex reflection, expression tree caching,
+            // and delegate compilation to the DLR. this results in reflection overhead only applying
+            // to the first call; subsequent calls perform similar to statically-compiled statements.
+            return handler.Read( (dynamic)source, comparer, cancellationToken );
+        }
+    }
+}

--- a/src/Dataflows/Sources/Internal/ValidationDecorator.cs
+++ b/src/Dataflows/Sources/Internal/ValidationDecorator.cs
@@ -1,0 +1,54 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Validation;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    /// <summary>
+    /// Decorates a source handler to add pre-execution validation support.
+    /// </summary>
+    /// <typeparam name="TSource">Type of the dataflow record source.</typeparam>
+
+    public class ValidationDecorator<TSource> : SourceHandler<TSource> where TSource : Source
+    {
+        internal readonly ISourceHandler<TSource> inner;
+        internal readonly IValidationAdapter<TSource> validator;
+
+        /// <summary>
+        /// Decorates a source handler to add pre-execution validation support.
+        /// </summary>
+        /// <param name="inner">Source handler to decorate.</param>
+        /// <param name="validator">Validation adapter for the source type.</param>
+
+        public ValidationDecorator( ISourceHandler<TSource> inner, IValidationAdapter<TSource> validator )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+            this.validator = validator ?? throw new ArgumentNullException( nameof( validator ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if validation of the source fails.
+        /// </summary>
+        /// <param name="source">Dataflow record source.</param>
+        /// <param name="comparer">String comparer for record field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of records.</returns>
+
+        protected override async IAsyncEnumerable<Record> Read( TSource source, StringComparer comparer, [EnumeratorCancellation] CancellationToken cancellationToken )
+        {
+            await validator.ValidateAndThrow( source, cancellationToken );
+
+            await foreach ( var record in inner.Read( source, comparer, cancellationToken ) )
+            {
+                yield return record;
+            }
+        }
+    }
+}

--- a/src/Dataflows/Sources/Source.cs
+++ b/src/Dataflows/Sources/Source.cs
@@ -1,0 +1,15 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Validation;
+
+namespace Shipwright.Dataflows.Sources
+{
+    /// <summary>
+    /// Defines a dataflow record source.
+    /// </summary>
+
+    public abstract record Source : IRequiresValidation { }
+}

--- a/src/Dataflows/Sources/SourceHandler.cs
+++ b/src/Dataflows/Sources/SourceHandler.cs
@@ -1,0 +1,39 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources
+{
+    /// <summary>
+    /// Defines a handler for a dataflow record source.
+    /// </summary>
+    /// <typeparam name="TSource">Type of the dataflow source.</typeparam>
+
+    public abstract class SourceHandler<TSource> : ISourceHandler<TSource> where TSource : Source
+    {
+        /// <summary>
+        /// Reads data from the given data source.
+        /// The source argument will be non-null.
+        /// </summary>
+        /// <param name="source">Dataflow record source definition.</param>
+        /// <param name="comparer">String comparer for field names.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>An awaitable stream of dataflow records.</returns>
+
+        protected abstract IAsyncEnumerable<Record> Read( TSource source, StringComparer comparer, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Explicit implementation of <see cref="ISourceHandler{TSource}"/>.
+        /// </summary>
+
+        IAsyncEnumerable<Record> ISourceHandler<TSource>.Read( TSource source, StringComparer comparer, CancellationToken cancellationToken )
+        {
+            return source == null ? throw new ArgumentNullException( nameof( source ) ) : Read( source, comparer, cancellationToken );
+        }
+    }
+}

--- a/test/Dataflows/Sources/FakeSource.cs
+++ b/test/Dataflows/Sources/FakeSource.cs
@@ -1,0 +1,14 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+
+namespace Shipwright.Dataflows.Sources
+{
+    public record FakeSource : Source
+    {
+        public Guid Value { get; } = Guid.NewGuid();
+    }
+}

--- a/test/Dataflows/Sources/Internal/CancellationDecoratorTests.cs
+++ b/test/Dataflows/Sources/Internal/CancellationDecoratorTests.cs
@@ -1,0 +1,112 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using AutoFixture.Xunit2;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    public class CancellationDecoratorTests
+    {
+        private ISourceHandler<FakeSource> inner;
+        private ISourceHandler<FakeSource> instance() => new CancellationDecorator<FakeSource>( inner );
+
+        private readonly Mock<ISourceHandler<FakeSource>> mockInner;
+
+        public CancellationDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+        }
+
+        public class Constructor : CancellationDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+        }
+
+        public class Read : CancellationDecoratorTests
+        {
+            private FakeSource source = new FakeSource();
+            private StringComparer comparer;
+            private CancellationToken cancellationToken;
+
+            private async Task<List<Record>> method() => await instance().Read( source, comparer, cancellationToken ).ToListAsync();
+
+            [Fact]
+            public async Task requires_source()
+            {
+                source = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( source ), method );
+            }
+
+            [Theory, AutoData]
+            public async Task throws_when_canceled_early( StringComparer comparer )
+            {
+                this.comparer = comparer;
+                cancellationToken = new CancellationToken( true );
+
+                await Assert.ThrowsAsync<OperationCanceledException>( method );
+            }
+
+            [Theory, AutoData]
+            public async Task throws_when_canceled_late( StringComparer comparer )
+            {
+                this.comparer = comparer;
+
+                using var cts = new CancellationTokenSource();
+                cancellationToken = cts.Token;
+
+                var fixture = new Fixture();
+                var records = Enumerable.Range( 0, 3 ).Select( position => new Record( source, fixture.Create<IDictionary<string, object>>(), position, comparer ) ).ToArray();
+
+                async IAsyncEnumerable<Record> callback()
+                {
+                    foreach ( var record in records )
+                    {
+                        yield return record;
+                        cts.Cancel();
+                    }
+                }
+
+                mockInner.Setup( _ => _.Read( source, comparer, cancellationToken ) ).Returns( callback );
+                await Assert.ThrowsAsync<OperationCanceledException>( method );
+            }
+
+            [Theory, AutoData]
+            public async Task returns_records( StringComparer comparer )
+            {
+                this.comparer = comparer;
+                cancellationToken = new CancellationToken( false );
+
+                var fixture = new Fixture();
+                var expected = Enumerable.Range( 0, 3 ).Select( position => new Record( source, fixture.Create<IDictionary<string, object>>(), position, comparer ) ).ToArray();
+
+                async IAsyncEnumerable<Record> callback()
+                {
+                    foreach ( var record in expected )
+                    {
+                        yield return record;
+                    }
+                }
+
+                mockInner.Setup( _ => _.Read( source, comparer, cancellationToken ) ).Returns( callback );
+
+                var actual = await method();
+                Assert.Equal( expected, actual );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Sources/Internal/SourceArgumentCases.cs
+++ b/test/Dataflows/Sources/Internal/SourceArgumentCases.cs
@@ -1,0 +1,27 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using Xunit;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    public class SourceArgumentCases : TheoryData<StringComparer, bool>
+    {
+        public SourceArgumentCases()
+        {
+            var comparers = new[] { StringComparer.Ordinal, StringComparer.OrdinalIgnoreCase };
+            var booealns = new[] { true, false };
+
+            foreach ( var comparer in comparers )
+            {
+                foreach ( var canceled in booealns )
+                {
+                    Add( comparer, canceled );
+                }
+            }
+        }
+    }
+}

--- a/test/Dataflows/Sources/Internal/SourceDispatcherTests.cs
+++ b/test/Dataflows/Sources/Internal/SourceDispatcherTests.cs
@@ -1,0 +1,109 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using Moq;
+using Shipwright.Resources;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Dataflows.Sources.Internal
+{
+    public class SourceDispatcherTests
+    {
+        private IServiceProvider serviceProvider;
+
+        private ISourceDispatcher instance() => new SourceDispatcher( serviceProvider );
+
+        private readonly Mock<IServiceProvider> mockServiceProvider;
+
+        public SourceDispatcherTests()
+        {
+            mockServiceProvider = Mockery.Of( out serviceProvider );
+        }
+
+        public class Constructor : SourceDispatcherTests
+        {
+            [Fact]
+            public void requires_serviceProvider()
+            {
+                serviceProvider = null!;
+                Assert.Throws<ArgumentNullException>( nameof( serviceProvider ), instance );
+            }
+        }
+
+        public class Read : SourceDispatcherTests
+        {
+            private Source source = new FakeSource();
+            private StringComparer comparer;
+            private CancellationToken cancellationToken;
+
+            private async Task<List<Record>> method() => await instance().Read( source, comparer, cancellationToken ).ToListAsync();
+
+            [Fact]
+            public async Task requires_source()
+            {
+                source = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( source ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_handler_not_found()
+            {
+                mockServiceProvider.Setup( _ => _.GetService( typeof( ISourceHandler<FakeSource> ) ) ).Returns( null ).Verifiable();
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>( method );
+                Assert.Equal( string.Format( CoreErrorMessages.MissingRequiredImplementation, typeof( ISourceHandler<FakeSource> ) ), actual.Message );
+            }
+
+            public class ArgumentCases : TheoryData<StringComparer, bool>
+            {
+                public ArgumentCases()
+                {
+                    var comparers = new[] { StringComparer.Ordinal, StringComparer.OrdinalIgnoreCase };
+                    var booealns = new[] { true, false };
+
+                    foreach ( var comparer in comparers )
+                    {
+                        foreach ( var canceled in booealns )
+                        {
+                            Add( comparer, canceled );
+                        }
+                    }
+                }
+            }
+
+            [Theory, ClassData( typeof( ArgumentCases ) )]
+            public async Task returns_records( StringComparer comparer, bool canceled )
+            {
+                this.comparer = comparer;
+                cancellationToken = new CancellationToken( canceled );
+
+                var mockHandler = Mockery.Of( out ISourceHandler<FakeSource> handler );
+                mockServiceProvider.Setup( _ => _.GetService( typeof( ISourceHandler<FakeSource> ) ) ).Returns( handler );
+
+                var fixture = new Fixture();
+                var expected = Enumerable.Range( 0, 3 ).Select( position => new Record( source, fixture.Create<IDictionary<string, object>>(), position, comparer ) ).ToArray();
+
+                async IAsyncEnumerable<Record> callback()
+                {
+                    foreach ( var record in expected )
+                    {
+                        yield return record;
+                    }
+                }
+
+                mockHandler.Setup( _ => _.Read( (FakeSource)source, comparer, cancellationToken ) ).Returns( callback );
+
+                var actual = await method();
+                Assert.Equal( expected, actual );
+            }
+        }
+    }
+}

--- a/test/Shipwright.Core.Test.csproj
+++ b/test/Shipwright.Core.Test.csproj
@@ -8,8 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200812-03" />
     <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1420
---
### Problem
As a developer, I want to express a data source as a plain class object so that:
- Usage is consistent with the established command pattern.
- Cross-cutting concerns like validation and cancellation can be handled outside of command logic.

### Solution
- Added a dispatch mechanism that allows a serializable data source to be declared independently of its execution.
- Defined abstractions for implementing source logic.
- Applied validation and cancellation logic using the decorator pattern.