### PR TITLE
NET-1385: Record events and inspection

### DIFF
--- a/lamar/src/Dataflows/LamarDataflowExtensions.cs
+++ b/lamar/src/Dataflows/LamarDataflowExtensions.cs
@@ -28,7 +28,8 @@ namespace Shipwright
             .AddSourceCancellation()
             .AddTransformationDispatch()
             .AddTransformationValidation()
-            .AddTransformationCancellation();
+            .AddTransformationCancellation()
+            .AddTransformationEventInspection();
 
         /// <summary>
         /// Adds all scanned implementations of dataflow components.

--- a/lamar/src/Dataflows/LamarDataflowTransformationExtensions.cs
+++ b/lamar/src/Dataflows/LamarDataflowTransformationExtensions.cs
@@ -72,5 +72,19 @@ namespace Shipwright.Dataflows
             registry.For( typeof( ITransformationFactory<> ) ).DecorateAllWith( typeof( CancellationFactoryDecorator<> ) );
             return registry;
         }
+
+        /// <summary>
+        /// Adds the event inspection decorator to all implementations of <see cref="ITransformationFactory{TTransformation}"/>.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddTransformationEventInspection( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For( typeof( ITransformationFactory<> ) ).DecorateAllWith( typeof( EventInspectionFactoryDecorator<> ) );
+            return registry;
+        }
     }
 }

--- a/lamar/test/Dataflows/LamarDataflowExtensionsTests.cs
+++ b/lamar/test/Dataflows/LamarDataflowExtensionsTests.cs
@@ -90,8 +90,11 @@ namespace Shipwright.Dataflows
                 using var container = new Container( registry );
                 var instance = container.GetInstance<ITransformationFactory<FakeTransformation>>();
 
-                // outer decorator should be cancellation
-                var cancellation = Assert.IsType<Transformations.Internal.CancellationFactoryDecorator<FakeTransformation>>( instance );
+                // outer decorator should be event inspection
+                var inspection = Assert.IsType<Transformations.Internal.EventInspectionFactoryDecorator<FakeTransformation>>( instance );
+
+                // next decorator should be cancellation
+                var cancellation = Assert.IsType<Transformations.Internal.CancellationFactoryDecorator<FakeTransformation>>( inspection.inner );
 
                 // inner decorator should be validation
                 var validation = Assert.IsType<Transformations.Internal.ValidationFactoryDecorator<FakeTransformation>>( cancellation.inner );

--- a/lamar/test/Dataflows/LamarDataflowTransformationExtensionsTests.cs
+++ b/lamar/test/Dataflows/LamarDataflowTransformationExtensionsTests.cs
@@ -136,5 +136,32 @@ namespace Shipwright.Dataflows
                 Assert.Same( inner, decorator.inner );
             }
         }
+
+        public class AddTransformationEventInspection : LamarDataflowTransformationExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddTransformationEventInspection();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void decorates_handler()
+            {
+                var inner = Mockery.Of<ITransformationFactory<FakeTransformation>>();
+                registry.For<ITransformationFactory<FakeTransformation>>().Add( inner );
+
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<ITransformationFactory<FakeTransformation>>();
+                var decorator = Assert.IsType<EventInspectionFactoryDecorator<FakeTransformation>>( instance );
+                Assert.Same( inner, decorator.inner );
+            }
+        }
     }
 }

--- a/src/Dataflows/Dataflow.cs
+++ b/src/Dataflows/Dataflow.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
 
+using Microsoft.Extensions.Logging;
 using Shipwright.Commands;
 using Shipwright.Dataflows.Sources;
 using Shipwright.Dataflows.Transformations;
@@ -58,5 +59,11 @@ namespace Shipwright.Dataflows
         /// </summary>
 
         public int MaxDegreeOfParallelism { get; init; } = DataflowBlockOptions.Unbounded;
+
+        /// <summary>
+        /// Log level that can be used by notification receivers for logging logic.
+        /// </summary>
+
+        public LogLevel LogLevel { get; init; }
     }
 }

--- a/src/Dataflows/LogEvent.cs
+++ b/src/Dataflows/LogEvent.cs
@@ -1,0 +1,42 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Shipwright.Dataflows
+{
+    /// <summary>
+    /// Represents a loggable event encountered during a dataflow.
+    /// </summary>
+
+    public record LogEvent
+    {
+        /// <summary>
+        /// Whether the event should stop record processing.
+        /// A fatal event will stop all subsequent transformations from processing on the associated record.
+        /// </summary>
+
+        public bool IsFatal { get; init; }
+
+        /// <summary>
+        /// Severity of the event.
+        /// </summary>
+
+        public LogLevel Level { get; init; }
+
+        /// <summary>
+        /// Description of the event.
+        /// </summary>
+
+        public string Description { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Value or values that provide context to the event.
+        /// The value is ideally serializable.
+        /// </summary>
+
+        public object? Value { get; init; }
+    }
+}

--- a/src/Dataflows/Record.cs
+++ b/src/Dataflows/Record.cs
@@ -47,6 +47,12 @@ namespace Shipwright.Dataflows
         public Source Source { get; init; }
 
         /// <summary>
+        /// Collection of events encountered during record processing.
+        /// </summary>
+
+        public ICollection<LogEvent> Events { get; } = new List<LogEvent>();
+
+        /// <summary>
         /// Constructs an instance to represent the given data within a dataflow.
         /// </summary>
         /// <param name="dataflow">Dataflow in which the record is processed.</param>

--- a/src/Dataflows/Transformations/Internal/EventInspectionFactoryDecorator.cs
+++ b/src/Dataflows/Transformations/Internal/EventInspectionFactoryDecorator.cs
@@ -1,0 +1,40 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations.Internal
+{
+    /// <summary>
+    /// Decorates a transformation factory to add event inspection to created handlers.
+    /// </summary>
+    /// <typeparam name="TTransformation">Type of the transformation.</typeparam>
+
+    public class EventInspectionFactoryDecorator<TTransformation> : TransformationFactory<TTransformation> where TTransformation : Transformation
+    {
+        internal readonly ITransformationFactory<TTransformation> inner;
+
+        /// <summary>
+        /// Decorates a transformation factory to add event inspection to created handlers.
+        /// </summary>
+        /// <param name="inner">Factory to decorate.</param>
+
+        public EventInspectionFactoryDecorator( ITransformationFactory<TTransformation> inner )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        /// <summary>
+        /// Adds a decorator to the created handler.
+        /// </summary>
+
+        protected override async Task<ITransformationHandler> Create( TTransformation transformation, CancellationToken cancellationToken )
+        {
+            return new EventInspectionHandlerDecorator( await inner.Create( transformation, cancellationToken ) );
+        }
+    }
+}

--- a/src/Dataflows/Transformations/Internal/EventInspectionHandlerDecorator.cs
+++ b/src/Dataflows/Transformations/Internal/EventInspectionHandlerDecorator.cs
@@ -1,0 +1,46 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations.Internal
+{
+    /// <summary>
+    /// Decorates a transformation handler to add event inspection and behavior.
+    /// </summary>
+
+    public class EventInspectionHandlerDecorator : TransformationHandler
+    {
+        internal readonly ITransformationHandler inner;
+
+        /// <summary>
+        /// Decorates a transformation handler to add event inspection and behavior.
+        /// </summary>
+
+        public EventInspectionHandlerDecorator( ITransformationHandler inner )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        /// <summary>
+        /// Inspects a record's events and skips processing when a fatal event is found.
+        /// </summary>
+
+        protected override async Task Transform( Record record, CancellationToken cancellationToken )
+        {
+            foreach ( var @event in record.Events )
+            {
+                if ( @event.IsFatal )
+                {
+                    return;
+                }
+            }
+
+            await inner.Transform( record, cancellationToken );
+        }
+    }
+}

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Dataflows/Transformations/Internal/CancellationHandlerDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/CancellationHandlerDecoratorTests.cs
@@ -66,5 +66,19 @@ namespace Shipwright.Dataflows.Transformations.Internal
                 mockInner.Verify();
             }
         }
+
+        public class DisposeAsync : CancellationHandlerDecoratorTests
+        {
+            private ValueTask method() => instance().DisposeAsync();
+
+            [Fact]
+            public async ValueTask disposes_inner_handler()
+            {
+                mockInner.Setup( _ => _.DisposeAsync() ).Returns( ValueTask.CompletedTask );
+
+                await method();
+                mockInner.Verify( _ => _.DisposeAsync(), Times.Once() );
+            }
+        }
     }
 }

--- a/test/Dataflows/Transformations/Internal/EventInspectionFactoryDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/EventInspectionFactoryDecoratorTests.cs
@@ -1,0 +1,65 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Dataflows.Transformations.Internal
+{
+    public class EventInspectionFactoryDecoratorTests
+    {
+        private ITransformationFactory<FakeTransformation> inner;
+        private ITransformationFactory<FakeTransformation> instance() => new EventInspectionFactoryDecorator<FakeTransformation>( inner );
+
+        private readonly Mock<ITransformationFactory<FakeTransformation>> mockInner;
+
+        public EventInspectionFactoryDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+        }
+
+        public class Constructor : EventInspectionFactoryDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+        }
+
+        public class Create : EventInspectionFactoryDecoratorTests
+        {
+            private FakeTransformation transformation = new FakeTransformation();
+            private CancellationToken cancellationToken;
+
+            private Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
+
+            [Fact]
+            public async ValueTask requires_transformation()
+            {
+                transformation = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task decorates_handler_from_inner_factory( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var handler = Mockery.Of<ITransformationHandler>();
+                mockInner.Setup( _ => _.Create( transformation, cancellationToken ) ).ReturnsAsync( handler );
+
+                var actual = await method();
+                var decorated = Assert.IsType<EventInspectionHandlerDecorator>( actual );
+                Assert.Same( handler, decorated.inner );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/Internal/EventInspectionHandlerDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/EventInspectionHandlerDecoratorTests.cs
@@ -1,0 +1,109 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Dataflows.Transformations.Internal
+{
+    public class EventInspectionHandlerDecoratorTests
+    {
+        private ITransformationHandler inner;
+        private ITransformationHandler instance() => new EventInspectionHandlerDecorator( inner );
+
+        private readonly Mock<ITransformationHandler> mockInner;
+
+        public EventInspectionHandlerDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+        }
+
+        public class Constructor : EventInspectionHandlerDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+        }
+
+        public class Transform : EventInspectionHandlerDecoratorTests
+        {
+            private Record record = FakeRecord.Create();
+            private CancellationToken cancellationToken;
+            private Task method() => instance().Transform( record, cancellationToken );
+
+            [Fact]
+            public async ValueTask requires_record()
+            {
+                record = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async ValueTask skips_inner_when_fatal_event( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var fixture = FakeRecord.Fixture();
+                var events = new[] { false, false, true }
+                    .Select( isFatal => fixture.Create<LogEvent>() with { IsFatal = isFatal } )
+                    .OrderBy( _ => Guid.NewGuid() )
+                    .ToArray();
+
+                foreach ( var @event in events )
+                {
+                    record.Events.Add( @event );
+                }
+
+                await method();
+                mockInner.Verify( _ => _.Transform( record, cancellationToken ), Times.Never() );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async ValueTask calls_inner_when_no_fatal_events( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var fixture = FakeRecord.Fixture();
+                var events = fixture.CreateMany<LogEvent>( 3 )
+                    .Select( e => e with { IsFatal = false } )
+                    .OrderBy( _ => Guid.NewGuid() )
+                    .ToArray();
+
+                foreach ( var @event in events )
+                {
+                    record.Events.Add( @event );
+                }
+
+                mockInner.Setup( _ => _.Transform( record, cancellationToken ) ).Returns( Task.CompletedTask );
+                await method();
+                mockInner.Verify( _ => _.Transform( record, cancellationToken ), Times.Once() );
+            }
+        }
+
+        public class DisposeAsync : EventInspectionHandlerDecoratorTests
+        {
+            private ValueTask method() => instance().DisposeAsync();
+
+            [Fact]
+            public async ValueTask disposes_inner_handler()
+            {
+                mockInner.Setup( _ => _.DisposeAsync() ).Returns( ValueTask.CompletedTask );
+
+                await method();
+                mockInner.Verify( _ => _.DisposeAsync(), Times.Once() );
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1385
---
### Problem
As a developer, I want to log events to records during processing and skip processing of records that contain "fatal" events so that I can use events to track loggable events and control when process flow should end.

### Solution
- Added a class type for loggable events.
- Added an event collection on the record type.
- Added a decorator to transformations that skips processing of records containing a fatal event.

### Additional Notes
Also added a LogLevel property to the dataflow command, which can be used (or ignored) by notification receivers to customize logging logic (e.g., by treating the property as the minimum event level required to trigger record logging).