### PR TITLE
NET-1451: Added event collection to dataflows for logging

### DIFF
--- a/src/Dataflows/Dataflow.cs
+++ b/src/Dataflows/Dataflow.cs
@@ -58,5 +58,11 @@ namespace Shipwright.Dataflows
         /// </summary>
 
         public int MaxDegreeOfParallelism { get; init; } = DataflowBlockOptions.Unbounded;
+
+        /// <summary>
+        /// Collection of events encountered during dataflow processing.
+        /// </summary>
+
+        public ICollection<LogEvent> Events { get; } = new List<LogEvent>();
     }
 }

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc1</Version>
+    <Version>1.0.0-preview.2</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1451
---
### Problem
While developing a data source, it was discovered there was no way to log any errors encountered while reading from the source.

### Solution
Added an events collection to the executing dataflow.

Consideration was given to adding the event collection to the source instead, but this would require adding another notification for source completion. Such a notification could in turn cause confusion since some sources would be unexpected (because they delegate to other sources). Additional confusion might be cause when the source completion notification is sent prior to all of the completion of all records from that source.

In this case, most any error in the source could easily be clearly represented as an event on the executing dataflow and re-use the existing dataflow completion notification.

### Additional Notes
Previous generations did not handle source errors at all; exceptions were simply logged to the console.