### PR TITLE
NET-1386: Made dataflow validator inheritable

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc1</Version>
+    <Version>1.0.0-preview.2.1</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Dataflows/Dataflow.Validator.cs
+++ b/src/Dataflows/Dataflow.Validator.cs
@@ -11,13 +11,14 @@ namespace Shipwright.Dataflows
     public partial record Dataflow
     {
         /// <summary>
-        /// Validator for dataflow commands.
+        /// Defines a validator for commands that derive from <see cref="Dataflow"/>.
         /// </summary>
+        /// <typeparam name="TDataflow">Derived type.</typeparam>
 
-        public class Validator : AbstractValidator<Dataflow>
+        public abstract class Validator<TDataflow> : AbstractValidator<TDataflow> where TDataflow : Dataflow
         {
             /// <summary>
-            /// Validator for dataflow commands.
+            /// Rules for all dataflow commands.
             /// </summary>
 
             public Validator()
@@ -29,5 +30,11 @@ namespace Shipwright.Dataflows
                 RuleFor( _ => _.MaxDegreeOfParallelism ).GreaterThan( 0 ).When( _ => _.MaxDegreeOfParallelism != DataflowBlockOptions.Unbounded );
             }
         }
+
+        /// <summary>
+        /// Validator for the stock dataflow command.
+        /// </summary>
+
+        public class Validator : Validator<Dataflow> { }
     }
 }

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.0-preview.2.1</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>


### PR DESCRIPTION
[NET-1386](https://seaseducation.atlassian.net/browse/NET-1386)
---
### Problem
As a developer, I want to be able to inherit validation rules for the dataflow command so that I can validate command that derive from `Dataflow` without having to copy the rules.

### Solution
Abstracted dataflow validator logic.