### PR TITLE
NET-1463: Required value transformation

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.2.3</Version>
+    <Version>1.0.0-preview.2.4</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Dataflows/Transformations/RequiredValue.Factory.cs
+++ b/src/Dataflows/Transformations/RequiredValue.Factory.cs
@@ -1,0 +1,31 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record RequiredValue
+    {
+        /// <summary>
+        /// Factory for creating handlers for the <see cref="RequiredValue"/> transformation.
+        /// </summary>
+
+        public class Factory : ITransformationFactory<RequiredValue>
+        {
+            /// <summary>
+            /// Creates a handler for the given transformation.
+            /// </summary>
+
+            public async Task<ITransformationHandler> Create( RequiredValue transformation, CancellationToken cancellationToken )
+            {
+                if ( transformation == null ) throw new ArgumentNullException( nameof( transformation ) );
+                return new Handler( transformation );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/RequiredValue.Handler.cs
+++ b/src/Dataflows/Transformations/RequiredValue.Handler.cs
@@ -1,0 +1,58 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record RequiredValue
+    {
+        /// <summary>
+        /// Handler for the <see cref="RequiredValue"/> transformation.
+        /// </summary>
+
+        public class Handler : TransformationHandler
+        {
+            internal readonly RequiredValue transformation;
+
+            /// <summary>
+            /// Handler for the <see cref="RequiredValue"/> transformation.
+            /// </summary>
+
+            public Handler( RequiredValue transformation )
+            {
+                this.transformation = transformation ?? throw new ArgumentNullException( nameof( transformation ) );
+            }
+
+            /// <summary>
+            /// Ensures the record has values in required fields.
+            /// </summary>
+
+            public override async Task Transform( Record record, CancellationToken cancellationToken )
+            {
+                if ( record == null ) throw new ArgumentNullException( nameof( record ) );
+
+                foreach ( var field in transformation.Fields )
+                {
+                    var missing = !record.Data.TryGetValue( field, out var value ) || value == null;
+                    missing |= !transformation.AllowBlank && value is string text && string.IsNullOrWhiteSpace( text );
+
+                    if ( missing )
+                    {
+                        record.Data.Remove( field );
+                        record.Events.Add( new LogEvent
+                        {
+                            IsFatal = transformation.ViolationIsFatal,
+                            Level = transformation.ViolationLogLevel,
+                            Description = transformation.ViolationDescription( field ),
+                        } );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/RequiredValue.Validator.cs
+++ b/src/Dataflows/Transformations/RequiredValue.Validator.cs
@@ -1,0 +1,29 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record RequiredValue
+    {
+        /// <summary>
+        /// Validator for the <see cref="RequiredValue"/> transformation.
+        /// </summary>
+
+        public class Validator : AbstractValidator<RequiredValue>
+        {
+            /// <summary>
+            /// Validator for the <see cref="RequiredValue"/> transformation.
+            /// </summary>
+
+            public Validator()
+            {
+                RuleFor( _ => _.Fields ).NotNull().NoNullElements().NoWhiteSpaceElements();
+                RuleFor( _ => _.ViolationDescription ).NotNull();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/RequiredValue.cs
+++ b/src/Dataflows/Transformations/RequiredValue.cs
@@ -1,0 +1,59 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    /// <summary>
+    /// Transformation that ensures that required fields are present and have values.
+    /// </summary>
+
+    public partial record RequiredValue : Transformation
+    {
+        /// <summary>
+        /// Names of the fields that should have values.
+        /// </summary>
+
+        public ICollection<string> Fields { get; init; } = new List<string>();
+
+        /// <summary>
+        /// Whether to consider blank/whitespace values as valid.
+        /// Defaults to true.
+        /// </summary>
+
+        public bool AllowBlank { get; init; } = true;
+
+        /// <summary>
+        /// Whether violations should stop record processing.
+        /// Defaults to true.
+        /// </summary>
+
+        public bool ViolationIsFatal { get; init; } = true;
+
+        /// <summary>
+        /// Log level to use for violation events.
+        /// Defaults to <see cref="LogLevel.Error"/>.
+        /// </summary>
+
+        public LogLevel ViolationLogLevel { get; init; } = LogLevel.Error;
+
+        /// <summary>
+        /// Defines a delegate for building the description of violation events.
+        /// </summary>
+        /// <param name="field">Name of the required field.</param>
+        /// <returns>A violation event description.</returns>
+
+        public delegate string ViolationDescriptionDelegate( string field );
+
+        /// <summary>
+        /// Optional delegate for building violation event descriptions.
+        /// </summary>
+
+        public ViolationDescriptionDelegate ViolationDescription { get; init; } =
+            field => string.Format( Resources.CoreErrorMessages.MissingRequiredFieldValue, field );
+    }
+}

--- a/src/Resources/CoreErrorMessages.Designer.cs
+++ b/src/Resources/CoreErrorMessages.Designer.cs
@@ -61,6 +61,15 @@ namespace Shipwright.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required value is missing from the field [{0}].
+        /// </summary>
+        public static string MissingRequiredFieldValue {
+            get {
+                return ResourceManager.GetString("MissingRequiredFieldValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to find a required implementation of the type {0}.
         /// </summary>
         public static string MissingRequiredImplementation {

--- a/src/Resources/CoreErrorMessages.resx
+++ b/src/Resources/CoreErrorMessages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="MissingRequiredFieldValue" xml:space="preserve">
+    <value>Required value is missing from the field [{0}]</value>
+  </data>
   <data name="MissingRequiredImplementation" xml:space="preserve">
     <value>Unable to find a required implementation of the type {0}</value>
   </data>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.2.3</Version>
+    <Version>1.0.0-preview.2.4</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/test/Dataflows/Transformations/RequiredValueTests/FactoryTests.cs
+++ b/test/Dataflows/Transformations/RequiredValueTests/FactoryTests.cs
@@ -1,0 +1,40 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.RequiredValue;
+
+namespace Shipwright.Dataflows.Transformations.RequiredValueTests
+{
+    public class FactoryTests
+    {
+        private ITransformationFactory<RequiredValue> instance() => new Factory();
+
+        public class Create : FactoryTests
+        {
+            private RequiredValue transformation = new Fixture().Create<RequiredValue>();
+
+            private Task<ITransformationHandler> method() => instance().Create( transformation, default );
+
+            [Fact]
+            public async Task requires_transformation()
+            {
+                transformation = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );
+            }
+
+            [Fact]
+            public async Task returns_handler()
+            {
+                var actual = await method();
+                var typed = Assert.IsType<Handler>( actual );
+                Assert.Same( transformation, typed.transformation );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/RequiredValueTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/RequiredValueTests/HandlerTests.cs
@@ -1,0 +1,175 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.RequiredValue;
+
+namespace Shipwright.Dataflows.Transformations.RequiredValueTests
+{
+    public class HandlerTests
+    {
+        private RequiredValue transformation = new Fixture().Create<RequiredValue>();
+        private ITransformationHandler instance() => new Handler( transformation );
+
+        public class Constructor : HandlerTests
+        {
+            [Fact]
+            public void requires_transformation()
+            {
+                transformation = null!;
+                Assert.Throws<ArgumentNullException>( nameof( transformation ), instance );
+            }
+        }
+
+        public class ViolationDescription
+        {
+            [Theory, AutoData]
+            public void defaults_to_resource_message( string field )
+            {
+                var actual = new RequiredValue().ViolationDescription( field );
+                actual.Should().Be( string.Format( Resources.CoreErrorMessages.MissingRequiredFieldValue, field ) );
+            }
+        }
+
+        public class Transform : HandlerTests
+        {
+            private Record record = FakeRecord.Create();
+            private Task method() => instance().Transform( record, default );
+
+            private readonly Fixture fixture = new Fixture();
+
+            [Fact]
+            public async Task requires_record()
+            {
+                record = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
+            }
+
+            [Fact]
+            public async Task adds_event_when_field_missing()
+            {
+                var description = Guid.NewGuid().ToString() + " {0}";
+                var expectedEvents = new List<LogEvent>();
+
+                transformation = transformation with
+                {
+                    Fields = new List<string>( fixture.CreateMany<string>( 3 ) ),
+                    ViolationDescription = field => string.Format( description, field ),
+                };
+
+                foreach ( var field in transformation.Fields )
+                {
+                    record.Data.Remove( field );
+                    expectedEvents.Add( new LogEvent
+                    {
+                        IsFatal = transformation.ViolationIsFatal,
+                        Level = transformation.ViolationLogLevel,
+                        Description = transformation.ViolationDescription( field ),
+                    } );
+                }
+
+                var expectedData = new Dictionary<string, object>( record.Data );
+                await method();
+
+                record.Data.Should().BeEquivalentTo( expectedData );
+                record.Events.Should().BeEquivalentTo( expectedEvents );
+            }
+
+            [Fact]
+            public async Task adds_event_when_field_value_is_null()
+            {
+                var description = Guid.NewGuid().ToString() + " {0}";
+
+                transformation = transformation with
+                {
+                    Fields = new List<string>( fixture.CreateMany<string>( 3 ) ),
+                    ViolationDescription = field => string.Format( description, field ),
+                };
+
+                var expectedEvents = new List<LogEvent>();
+                var expectedData = new Dictionary<string, object>( record.Data );
+
+                foreach ( var field in transformation.Fields )
+                {
+                    // we expect the transformation to remove the field from the data set
+                    expectedData.Remove( field );
+                    record.Data[field] = null;
+                    expectedEvents.Add( new LogEvent
+                    {
+                        IsFatal = transformation.ViolationIsFatal,
+                        Level = transformation.ViolationLogLevel,
+                        Description = transformation.ViolationDescription( field ),
+                    } );
+                }
+
+                await method();
+
+                record.Data.Should().BeEquivalentTo( expectedData );
+                record.Events.Should().BeEquivalentTo( expectedEvents );
+            }
+
+            [Theory, ClassData( typeof( Cases.WhiteSpaceCases ) )]
+            public async Task adds_event_when_field_value_is_blank_and_not_allowed( string value )
+            {
+                var description = Guid.NewGuid().ToString() + " {0}";
+
+                transformation = transformation with
+                {
+                    Fields = new List<string>( fixture.CreateMany<string>( 3 ) ),
+                    ViolationDescription = field => string.Format( description, field ),
+                    AllowBlank = false,
+                };
+
+                var expectedEvents = new List<LogEvent>();
+                var expectedData = new Dictionary<string, object>( record.Data );
+
+                foreach ( var field in transformation.Fields )
+                {
+                    // we expect the transformation to remove the field from the data set
+                    expectedData.Remove( field );
+                    record.Data[field] = value;
+                    expectedEvents.Add( new LogEvent
+                    {
+                        IsFatal = transformation.ViolationIsFatal,
+                        Level = transformation.ViolationLogLevel,
+                        Description = transformation.ViolationDescription( field ),
+                    } );
+                }
+
+                await method();
+
+                record.Data.Should().BeEquivalentTo( expectedData );
+                record.Events.Should().BeEquivalentTo( expectedEvents );
+            }
+
+            [Theory, ClassData( typeof( Cases.WhiteSpaceCases ) )]
+            public async Task retains_value_when_field_value_is_blank_and_allowed( string value )
+            {
+                transformation = transformation with
+                {
+                    Fields = new List<string>( fixture.CreateMany<string>( 3 ) ),
+                    AllowBlank = true,
+                };
+
+                foreach ( var field in transformation.Fields )
+                {
+                    record.Data[field] = value;
+                }
+
+                var expectedData = new Dictionary<string, object>( record.Data );
+                await method();
+
+                record.Data.Should().BeEquivalentTo( expectedData );
+                record.Events.Should().BeEmpty();
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/RequiredValueTests/ValidatorTests.cs
+++ b/test/Dataflows/Transformations/RequiredValueTests/ValidatorTests.cs
@@ -1,0 +1,43 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using FluentValidation;
+using System.Collections.Generic;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.RequiredValue;
+
+namespace Shipwright.Dataflows.Transformations.RequiredValueTests
+{
+    public class ValidatorTests
+    {
+        private readonly IValidator<RequiredValue> validator = new Validator();
+        private readonly Fixture fixture = new Fixture();
+
+        public class Fields : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Fields, null );
+
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_null_or_whitespace_elements( string value ) => validator.InvalidWhen( _ => _.Fields, new List<string>( fixture.CreateMany<string>() ) { value } );
+
+            [Fact]
+            public void valid_when_empty() => validator.ValidWhen( _ => _.Fields, new List<string>() );
+
+            [Fact]
+            public void valid_when_no_null_elements() => validator.ValidWhen( _ => _.Fields, new List<string>( fixture.CreateMany<string>() ) );
+        }
+
+        public class ViolationDescription : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.ViolationDescription, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.ViolationDescription, _ => fixture.Create<string>() );
+        }
+    }
+}


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1463
---
### Problem
As an ETL developer, I want to configure a transformation that will make field(s) required so that I can validate that records have values in critical fields. I should be able to configure:

- Whether blank/whitespace values are allowed
- Whether a violation stops record processing
- The level and description of any log event generated by violations.

### Solution
Added a transformation meeting the criteria above.