### PR TITLE
NET-1465: Database lookup transformation

### DIFF
--- a/lamar/src/Databases/LamarDatabaseExtensions.cs
+++ b/lamar/src/Databases/LamarDatabaseExtensions.cs
@@ -1,0 +1,76 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Lamar;
+using Lamar.Scanning.Conventions;
+using Shipwright.Databases;
+using Shipwright.Databases.Internal;
+using System;
+
+namespace Shipwright
+{
+    /// <summary>
+    /// Extension methods for registering database types with Lamar.
+    /// </summary>
+
+    public static class LamarDatabaseExtensions
+    {
+        /// <summary>
+        /// Adds the stock Shipwright connection dispatcher.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddDbConnectionDispatch( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For<IDbConnectionDispatcher>().Add<DbConnectionDispatcher>();
+            return registry;
+        }
+
+        /// <summary>
+        /// Adds all implementations of <see cref="IDbConnectionBuilder{TConnectionInfo}"/> found in the scanned assemblies.
+        /// </summary>
+        /// <param name="scanner">Lamar assembly scanner.</param>
+        /// <returns>The assembly scanner.</returns>
+
+        public static IAssemblyScanner AddDbConnectionBuilders( this IAssemblyScanner scanner )
+        {
+            if ( scanner == null ) throw new ArgumentNullException( nameof( scanner ) );
+
+            scanner.ConnectImplementationsToTypesClosing( typeof( IDbConnectionBuilder<> ) );
+            return scanner;
+        }
+
+        /// <summary>
+        /// Adds the connection validation decorator to all implementations of <see cref="IDbConnectionBuilder{TConnectionInfo}"/>.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddDbConnectionValidation( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For( typeof( IDbConnectionBuilder<> ) ).DecorateAllWith( typeof( ValidationDecorator<> ) );
+            return registry;
+        }
+
+        /// <summary>
+        /// Adds the cancellation decorator to all implementations of <see cref="IDbConnectionBuilder{TConnectionInfo}"/>.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddDbConnectionCancellation( this ServiceRegistry registry )
+        {
+            if ( registry == null ) throw new ArgumentNullException( nameof( registry ) );
+
+            registry.For( typeof( IDbConnectionBuilder<> ) ).DecorateAllWith( typeof( CancellationDecorator<> ) );
+            return registry;
+        }
+    }
+}

--- a/lamar/src/Dataflows/LamarDataflowExtensions.cs
+++ b/lamar/src/Dataflows/LamarDataflowExtensions.cs
@@ -41,5 +41,33 @@ namespace Shipwright
             .AddSourceHandlers()
             .AddTransformationFactories()
             .AddDataflowNotifications();
+
+        /// <summary>
+        /// Registers all Shipwright components.
+        /// </summary>
+        /// <param name="registry">Lamar service registry.</param>
+        /// <returns>The service registry.</returns>
+
+        public static ServiceRegistry AddAllShipwright( this ServiceRegistry registry ) => (registry ?? throw new ArgumentNullException( nameof( registry ) ))
+            .AddValidationAdapter()
+            .AddCommandDispatch()
+            .AddCommandValidation()
+            .AddCommandCancellation()
+            .AddDbConnectionDispatch()
+            .AddDbConnectionValidation()
+            .AddDbConnectionCancellation()
+            .AddDataflow();
+
+        /// <summary>
+        /// Adds all scanned Shipwright components.
+        /// </summary>
+        /// <param name="scanner">Lamar assembly scanner.</param>
+        /// <returns>The assembly scanner.</returns>
+
+        public static IAssemblyScanner AddAllShipwrightImplementations( this IAssemblyScanner scanner ) => (scanner ?? throw new ArgumentNullException( nameof( scanner ) ))
+            .AddValidators()
+            .AddCommandHandlers()
+            .AddDbConnectionBuilders()
+            .AddDataflowImplementations();
     }
 }

--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.2.4</Version>
+    <Version>1.0.0-preview.3</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/lamar/test/Databases/LamarDatabaseExtensionsTests.cs
+++ b/lamar/test/Databases/LamarDatabaseExtensionsTests.cs
@@ -1,0 +1,139 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Lamar;
+using Lamar.Scanning.Conventions;
+using Moq;
+using Shipwright.Databases.Internal;
+using Shipwright.Validation;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Databases
+{
+    public class LamarDatabaseExtensionsTests
+    {
+        private ServiceRegistry registry = new ServiceRegistry();
+
+        public class AddDbConnectionDispatch : LamarDatabaseExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddDbConnectionDispatch();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void registers_dispatcher()
+            {
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( actual );
+                var instance = container.GetInstance<IDbConnectionDispatcher>();
+                Assert.IsType<DbConnectionDispatcher>( instance );
+            }
+        }
+
+        public class AddDbConnectionBuilders : LamarDatabaseExtensionsTests
+        {
+            private IAssemblyScanner scanner;
+            private IAssemblyScanner method() => scanner.AddDbConnectionBuilders();
+
+            public class FakeConnectionBuilder : IDbConnectionBuilder<FakeConnectionInfo>
+            {
+                public Task<IDbConnectionFactory> Build( FakeConnectionInfo connectionInfo, CancellationToken cancellationToken ) =>
+                    throw new NotImplementedException();
+            }
+
+            [Fact]
+            public void requires_scanner()
+            {
+                scanner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( scanner ), method );
+            }
+
+            [Fact]
+            public void registers_discovered_builders()
+            {
+                registry.Scan( scanner =>
+                {
+                    this.scanner = scanner;
+                    scanner.AssemblyContainingType<DbConnectionInfo>(); // sanity check to ensure decorators aren't grabbed
+                    scanner.AssemblyContainingType<AddDbConnectionBuilders>();
+
+                    var actual = method();
+                    Assert.Same( this.scanner, actual );
+                } );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<IDbConnectionBuilder<FakeConnectionInfo>>();
+                Assert.IsType<FakeConnectionBuilder>( instance );
+            }
+        }
+
+        public class AddDbConnectionValidation : LamarDatabaseExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddDbConnectionValidation();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void decorates_handler()
+            {
+                var inner = Mockery.Of<IDbConnectionBuilder<FakeConnectionInfo>>();
+                var validator = Mockery.Of<IValidationAdapter<FakeConnectionInfo>>();
+                registry.For<IDbConnectionBuilder<FakeConnectionInfo>>().Add( inner );
+                registry.For<IValidationAdapter<FakeConnectionInfo>>().Add( validator );
+
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<IDbConnectionBuilder<FakeConnectionInfo>>();
+                var decorator = Assert.IsType<ValidationDecorator<FakeConnectionInfo>>( instance );
+                Assert.Same( inner, decorator.inner );
+                Assert.Same( validator, decorator.validator );
+            }
+        }
+
+        public class AddDbConnectionCancellation : LamarDatabaseExtensionsTests
+        {
+            private ServiceRegistry method() => registry.AddDbConnectionCancellation();
+
+            [Fact]
+            public void requires_registry()
+            {
+                registry = null!;
+                Assert.Throws<ArgumentNullException>( nameof( registry ), method );
+            }
+
+            [Fact]
+            public void decorates_handler()
+            {
+                var inner = Mockery.Of<IDbConnectionBuilder<FakeConnectionInfo>>();
+                registry.For<IDbConnectionBuilder<FakeConnectionInfo>>().Add( inner );
+
+                var actual = method();
+                Assert.Same( registry, actual );
+
+                using var container = new Container( registry );
+                var instance = container.GetInstance<IDbConnectionBuilder<FakeConnectionInfo>>();
+                var decorator = Assert.IsType<CancellationDecorator<FakeConnectionInfo>>( instance );
+                Assert.Same( inner, decorator.inner );
+            }
+        }
+    }
+}

--- a/src/Databases/DbConnectionInfo.cs
+++ b/src/Databases/DbConnectionInfo.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+namespace Shipwright.Databases
+{
+    /// <summary>
+    /// Defines connection information for interacting with a database.
+    /// </summary>
+
+    public abstract record DbConnectionInfo { }
+}

--- a/src/Databases/IDbConnectionBuilder.cs
+++ b/src/Databases/IDbConnectionBuilder.cs
@@ -13,7 +13,7 @@ namespace Shipwright.Databases
     /// </summary>
     /// <typeparam name="TConnectionInfo">Type of the database connection information.</typeparam>
     /// <remarks>
-    /// This abstration exists to support those cases where complex logic may be needed to compose
+    /// This abstraction exists to support those cases where complex logic may be needed to compose
     /// the root information for connecting to a database. For example, in a multi-tenant application
     /// where tenant databases may exist on different services, this allows an awaitable means of
     /// locating a specific database using an external service.

--- a/src/Databases/IDbConnectionBuilder.cs
+++ b/src/Databases/IDbConnectionBuilder.cs
@@ -1,0 +1,33 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Databases
+{
+    /// <summary>
+    /// Defines a builder for creating database connection factories.
+    /// </summary>
+    /// <typeparam name="TConnectionInfo">Type of the database connection information.</typeparam>
+    /// <remarks>
+    /// This abstration exists to support those cases where complex logic may be needed to compose
+    /// the root information for connecting to a database. For example, in a multi-tenant application
+    /// where tenant databases may exist on different services, this allows an awaitable means of
+    /// locating a specific database using an external service.
+    /// </remarks>
+
+    public interface IDbConnectionBuilder<TConnectionInfo> where TConnectionInfo : DbConnectionInfo
+    {
+        /// <summary>
+        /// Builds a factory for creating database connections for the given connection information.
+        /// </summary>
+        /// <param name="connectionInfo">Connection information of the database whose connection factory to build.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A factory for creating database connections.</returns>
+
+        Task<IDbConnectionFactory> Build( TConnectionInfo connectionInfo, CancellationToken cancellationToken );
+    }
+}

--- a/src/Databases/IDbConnectionDispatcher.cs
+++ b/src/Databases/IDbConnectionDispatcher.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Databases
+{
+    /// <summary>
+    /// Defines a dispatcher for locating and building a factory for creating database connections
+    /// for a <see cref="DbConnectionInfo"/> object.
+    /// </summary>
+
+    public interface IDbConnectionDispatcher
+    {
+        /// <summary>
+        /// Locates the builder for the given <see cref="DbConnectionInfo"/> and builds the database
+        /// connection factory.
+        /// </summary>
+        /// <param name="connectionInfo">Database connection information.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A factory for creating database connections for the specified database.</returns>
+
+        Task<IDbConnectionFactory> Build( DbConnectionInfo connectionInfo, CancellationToken cancellationToken );
+    }
+}

--- a/src/Databases/IDbConnectionFactory.cs
+++ b/src/Databases/IDbConnectionFactory.cs
@@ -1,0 +1,23 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Data;
+
+namespace Shipwright.Databases
+{
+    /// <summary>
+    /// Defines a factory for creating connections to the configured database.
+    /// </summary>
+
+    public interface IDbConnectionFactory
+    {
+        /// <summary>
+        /// Creates a connection to the configured database.
+        /// </summary>
+        /// <returns>A database connection.</returns>
+
+        IDbConnection Create();
+    }
+}

--- a/src/Databases/Internal/CancellationDecorator.cs
+++ b/src/Databases/Internal/CancellationDecorator.cs
@@ -1,0 +1,47 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Databases.Internal
+{
+    /// <summary>
+    /// Decorates a connection builder to add pre-execution cancellation support.
+    /// </summary>
+    /// <typeparam name="TConnectionInfo">Type of the connection information.</typeparam>
+
+    public class CancellationDecorator<TConnectionInfo> : IDbConnectionBuilder<TConnectionInfo> where TConnectionInfo : DbConnectionInfo
+    {
+        internal readonly IDbConnectionBuilder<TConnectionInfo> inner;
+
+        /// <summary>
+        /// Decorates a connection builder to add pre-execution cancellation support.
+        /// </summary>
+        /// <param name="inner">Connection builder to decorate.</param>
+
+        public CancellationDecorator( IDbConnectionBuilder<TConnectionInfo> inner )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if cancellation has been requested.
+        /// Otherwise awaits execution of the decorated builder.
+        /// </summary>
+        /// <param name="connectionInfo">Connection whose factory to build.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The factory built by the inner builder.</returns>
+
+        public async Task<IDbConnectionFactory> Build( TConnectionInfo connectionInfo, CancellationToken cancellationToken )
+        {
+            if ( connectionInfo == null ) throw new ArgumentNullException( nameof( connectionInfo ) );
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return await inner.Build( connectionInfo, cancellationToken );
+        }
+    }
+}

--- a/src/Databases/Internal/DbConnectionDispatcher.cs
+++ b/src/Databases/Internal/DbConnectionDispatcher.cs
@@ -1,0 +1,53 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Databases.Internal
+{
+    /// <summary>
+    /// Dispatcher for locating and building a factory for creating database connections
+    /// for a <see cref="DbConnectionInfo"/> object.
+    /// </summary>
+
+    public class DbConnectionDispatcher : IDbConnectionDispatcher
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        /// <summary>
+        /// Constructs a dispatcher for locating and building a factory for creating database connections
+        /// for a <see cref="DbConnectionInfo"/> object.
+        /// </summary>
+        /// <param name="serviceProvider">Dependency injection container or service provider.</param>
+
+        public DbConnectionDispatcher( IServiceProvider serviceProvider )
+        {
+            this.serviceProvider = serviceProvider ?? throw new ArgumentNullException( nameof( serviceProvider ) );
+        }
+
+        /// <summary>
+        /// Locates the builder for the given <see cref="DbConnectionInfo"/> and builds the database
+        /// connection factory.
+        /// </summary>
+
+        public async Task<IDbConnectionFactory> Build( DbConnectionInfo connectionInfo, CancellationToken cancellationToken )
+        {
+            if ( connectionInfo == null ) throw new ArgumentNullException( nameof( connectionInfo ) );
+
+            var connectionType = connectionInfo.GetType();
+            var builderType = typeof( IDbConnectionBuilder<> ).MakeGenericType( connectionType );
+
+            dynamic builder = serviceProvider.GetService( builderType ) ??
+                throw new InvalidOperationException( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, builderType ) );
+
+            // use of the dynamic type offloads the complex reflection, expression tree caching,
+            // and delegate compilation to the DLR. this results in reflection overhead only applying
+            // to the first call; subsequent calls perform similar to statically-compiled statements.
+            return await builder.Build( (dynamic)connectionInfo, cancellationToken );
+        }
+    }
+}

--- a/src/Databases/Internal/ValidationDecorator.cs
+++ b/src/Databases/Internal/ValidationDecorator.cs
@@ -1,0 +1,51 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Validation;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Databases.Internal
+{
+    /// <summary>
+    /// Decorates a connection builder to add pre-execution validation support.
+    /// </summary>
+    /// <typeparam name="TConnectionInfo">Type of the connection information.</typeparam>
+
+    public class ValidationDecorator<TConnectionInfo> : IDbConnectionBuilder<TConnectionInfo> where TConnectionInfo : DbConnectionInfo
+    {
+        internal readonly IDbConnectionBuilder<TConnectionInfo> inner;
+        internal readonly IValidationAdapter<TConnectionInfo> validator;
+
+        /// <summary>
+        /// Decorates a connection builder to add pre-execution validation support.
+        /// </summary>
+        /// <param name="inner">Builder to decorate.</param>
+        /// <param name="validator">Validation adapter for the connection information type.</param>
+
+        public ValidationDecorator( IDbConnectionBuilder<TConnectionInfo> inner, IValidationAdapter<TConnectionInfo> validator )
+        {
+            this.inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+            this.validator = validator ?? throw new ArgumentNullException( nameof( validator ) );
+        }
+
+        /// <summary>
+        /// Throws an exception if validation of the connection information fails.
+        /// Otherwise awaits execution of the decorated builder.
+        /// </summary>
+        /// <param name="connectionInfo">Connection whose factory to build.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A factory composed by the inner builder.</returns>
+
+        public async Task<IDbConnectionFactory> Build( TConnectionInfo connectionInfo, CancellationToken cancellationToken )
+        {
+            if ( connectionInfo == null ) throw new ArgumentNullException( nameof( connectionInfo ) );
+
+            await validator.ValidateAndThrow( connectionInfo, cancellationToken );
+            return await inner.Build( connectionInfo, cancellationToken );
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.CacheHandler.cs
+++ b/src/Dataflows/Transformations/DbLookup.CacheHandler.cs
@@ -1,0 +1,74 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Identifiable;
+using Shipwright.Databases;
+using Shipwright.Services.Caching;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbLookup
+    {
+        /// <summary>
+        /// Handler for the <see cref="DbLookup"/> transformation for when caching is enabled.
+        /// </summary>
+
+        public class CacheHandler : Handler
+        {
+            /// <summary>
+            /// Handler for the <see cref="DbLookup"/> transformation for when caching is enabled.
+            /// </summary>
+            /// <param name="transformation">Transformation settings.</param>
+            /// <param name="connectionFactory">Factory for creating database settings.</param>
+
+            public CacheHandler( DbLookup transformation, IDbConnectionFactory connectionFactory ) :
+                base( transformation, connectionFactory )
+            { }
+
+            /// <summary>
+            /// Cache for database results, indexed by a GUID key representing the input parameters.
+            /// </summary>
+
+            private readonly AsyncCache<Guid, IEnumerable<dynamic>> cache = new AsyncCache<Guid, IEnumerable<dynamic>>();
+
+            /// <summary>
+            /// Namespace for computing parameter keys.
+            /// </summary>
+
+            private readonly Guid @namespace = NamedGuid.Compute( NamedGuidAlgorithm.SHA1, Guid.Empty, "ns://seas.technology/cache" );
+
+            /// <summary>
+            /// Allows <see cref="GetMatches(IDictionary{string, object?}, CancellationToken)"/> to be mocked.
+            /// </summary>
+
+            public virtual Task<IEnumerable<dynamic>> GetMatchesEx( IDictionary<string, object?> parameters, CancellationToken cancellationToken ) =>
+                base.GetMatches( parameters, cancellationToken );
+
+            /// <summary>
+            /// Checks the cache for existing results for the parameters and calls the base
+            /// implementation on cache miss.
+            /// </summary>
+
+            public override async Task<IEnumerable<dynamic>> GetMatches( IDictionary<string, object?> parameters, CancellationToken cancellationToken )
+            {
+                // sanity check that restores base functionality when caching is not desired
+                if ( !transformation.CacheResults )
+                {
+                    return await GetMatchesEx( parameters, cancellationToken );
+                }
+
+                var json = JsonSerializer.Serialize( parameters );
+                var key = NamedGuid.Compute( NamedGuidAlgorithm.SHA1, @namespace, json );
+
+                return await cache.GetOrAdd( key, _ => GetMatchesEx( parameters, cancellationToken ) );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.Factory.cs
+++ b/src/Dataflows/Transformations/DbLookup.Factory.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Databases;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbLookup
+    {
+        /// <summary>
+        /// Factory for the <see cref="DbLookup"/> transformation.
+        /// </summary>
+
+        public class Factory : ITransformationFactory<DbLookup>
+        {
+            private readonly IDbConnectionDispatcher dispatcher;
+
+            /// <summary>
+            /// Factory for the <see cref="DbLookup"/> transformation.
+            /// </summary>
+
+            public Factory( IDbConnectionDispatcher dispatcher )
+            {
+                this.dispatcher = dispatcher ?? throw new ArgumentNullException( nameof( dispatcher ) );
+            }
+
+            /// <summary>
+            /// Creates a handler for the transformation.
+            /// </summary>
+
+            public async Task<ITransformationHandler> Create( DbLookup transformation, CancellationToken cancellationToken )
+            {
+                if ( transformation == null ) throw new ArgumentNullException( nameof( transformation ) );
+
+                var connectionFactory = await dispatcher.Build( transformation.ConnectionInfo, cancellationToken );
+                return new Handler( transformation, connectionFactory );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.Factory.cs
+++ b/src/Dataflows/Transformations/DbLookup.Factory.cs
@@ -38,7 +38,10 @@ namespace Shipwright.Dataflows.Transformations
                 if ( transformation == null ) throw new ArgumentNullException( nameof( transformation ) );
 
                 var connectionFactory = await dispatcher.Build( transformation.ConnectionInfo, cancellationToken );
-                return new Handler( transformation, connectionFactory );
+
+                return transformation.CacheResults
+                    ? new CacheHandler( transformation, connectionFactory )
+                    : new Handler( transformation, connectionFactory );
             }
         }
     }

--- a/src/Dataflows/Transformations/DbLookup.FailureEventSetting.cs
+++ b/src/Dataflows/Transformations/DbLookup.FailureEventSetting.cs
@@ -1,0 +1,40 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbLookup
+    {
+        /// <summary>
+        /// Describes settings to use for lookup failure events.
+        /// </summary>
+
+        public record FailureEventSetting
+        {
+            /// <summary>
+            /// Whether the lookup failure should stop record processing.
+            /// Defaults to true.
+            /// </summary>
+
+            public bool IsFatal { get; set; } = true;
+
+            /// <summary>
+            /// Log level to use for lookup failure events.
+            /// Defaults to <see cref="LogLevel.Error"/>.
+            /// </summary>
+
+            public LogLevel Level { get; set; } = LogLevel.Error;
+
+            /// <summary>
+            /// Delegate for generating failure event messages.
+            /// </summary>
+
+            public FailureEventMessageDelegate FailureEventMessage { get; init; } = count =>
+                string.Format( Resources.CoreErrorMessages.DbLookupFailureMessage, count );
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.Handler.cs
+++ b/src/Dataflows/Transformations/DbLookup.Handler.cs
@@ -1,0 +1,133 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Dapper;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbLookup
+    {
+        /// <summary>
+        /// Handler for the <see cref="DbLookup"/> transformation.
+        /// </summary>
+
+        public class Handler : TransformationHandler
+        {
+            private static readonly FailureEventMessageDelegate DefaultFailureMessage = count =>
+                string.Format( Resources.CoreErrorMessages.DbLookupFailureMessage, count );
+
+            internal DbLookup transformation;
+            internal IDbConnectionFactory connectionFactory;
+
+            /// <summary>
+            /// Handler for the <see cref="DbLookup"/> transformation.
+            /// </summary>
+            /// <param name="transformation">Transformation settings.</param>
+            /// <param name="connectionFactory">Factory for creating database settings.</param>
+
+            public Handler( DbLookup transformation, IDbConnectionFactory connectionFactory )
+            {
+                this.transformation = transformation ?? throw new ArgumentNullException( nameof( transformation ) );
+                this.connectionFactory = connectionFactory ?? throw new ArgumentNullException( nameof( connectionFactory ) );
+            }
+
+            /// <summary>
+            /// Maps values specified by input field names to a dictionary of parameter values.
+            /// </summary>
+
+            public virtual IDictionary<string, object?> MapInputs( Record record )
+            {
+                var parameters = new Dictionary<string, object?>();
+
+                foreach ( var (field, param) in transformation.Input )
+                {
+                    parameters[param] = record.Data.TryGetValue( field, out var value )
+                        ? value
+                        : null;
+                }
+
+                return parameters;
+            }
+
+            /// <summary>
+            /// Queries the database for matching records.
+            /// </summary>
+
+            public virtual async Task<IEnumerable<dynamic>> GetMatches( IDictionary<string, object?> parameters, CancellationToken cancellationToken )
+            {
+                var command = new CommandDefinition( transformation.Sql, parameters: parameters, cancellationToken: cancellationToken );
+
+                using var connection = connectionFactory.Create();
+                return await connection.QueryAsync( command );
+            }
+
+            /// <summary>
+            /// Locates the match to use for output mapping.
+            /// </summary>
+
+            public virtual bool TryGetResult( Record record, IEnumerable<dynamic> matches, object parameters, out IDictionary<string, object> result )
+            {
+                result = matches.FirstOrDefault()!;
+
+                if ( matches.Count() != 1 )
+                {
+                    var setting = matches.Count() switch
+                    {
+                        0 => transformation.QueryZeroRecordEvent,
+                        _ => transformation.QueryMultipleRecordEvent,
+                    };
+
+                    record.Events.Add( new LogEvent
+                    {
+                        IsFatal = setting.IsFatal,
+                        Level = setting.Level,
+                        Description = (setting.FailureEventMessage ?? DefaultFailureMessage).Invoke( matches.Count() ),
+                        Value = parameters,
+                    } );
+                }
+
+                return matches.Count() == 1;
+            }
+
+            /// <summary>
+            /// Maps the result item to output fields.
+            /// </summary>
+
+            public virtual void MapResult( Record record, IDictionary<string, object> result )
+            {
+                foreach ( var (field, column) in transformation.Output )
+                {
+                    if ( result.TryGetValue( column, out var value ) )
+                    {
+                        record.Data[field] = value;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Performs a database lookup and maps query results to output fields.
+            /// </summary>
+
+            public override async Task Transform( Record record, CancellationToken cancellationToken )
+            {
+                if ( record == null ) throw new ArgumentNullException( nameof( record ) );
+
+                var parameters = MapInputs( record );
+                var matches = await GetMatches( parameters, cancellationToken );
+
+                if ( TryGetResult( record, matches, parameters, out var result ) )
+                {
+                    MapResult( record, result );
+                }
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.Validator.cs
+++ b/src/Dataflows/Transformations/DbLookup.Validator.cs
@@ -19,6 +19,22 @@ namespace Shipwright.Dataflows.Transformations
         public class Validator : AbstractValidator<DbLookup>
         {
             /// <summary>
+            /// Validator for the <see cref="FailureEventSetting"/> subtype.
+            /// </summary>
+
+            public class FailureEventSettingValidator : AbstractValidator<FailureEventSetting>
+            {
+                /// <summary>
+                /// Validator for the <see cref="FailureEventSetting"/> subtype.
+                /// </summary>
+
+                public FailureEventSettingValidator()
+                {
+                    RuleFor( _ => _.FailureEventMessage ).NotNull();
+                }
+            }
+
+            /// <summary>
             /// Validator for the <see cref="DbLookup"/> transformation.
             /// </summary>
 
@@ -50,8 +66,8 @@ namespace Shipwright.Dataflows.Transformations
                 RuleFor( _ => _.ConnectionInfo ).NotNull();
                 RuleFor( _ => _.Input ).NotNull().Must( HaveDefinedValues );
                 RuleFor( _ => _.Output ).NotNull().Must( HaveDefinedValues );
-                RuleFor( _ => _.QueryMultipleRecordEvent ).NotNull();
-                RuleFor( _ => _.QueryZeroRecordEvent ).NotNull();
+                RuleFor( _ => _.QueryMultipleRecordEvent ).NotNull().SetValidator( new FailureEventSettingValidator() );
+                RuleFor( _ => _.QueryZeroRecordEvent ).NotNull().SetValidator( new FailureEventSettingValidator() );
                 RuleFor( _ => _.Sql ).NotNull().NotWhiteSpace();
             }
         }

--- a/src/Dataflows/Transformations/DbLookup.Validator.cs
+++ b/src/Dataflows/Transformations/DbLookup.Validator.cs
@@ -1,0 +1,59 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using FluentValidation.Validators;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbLookup
+    {
+        /// <summary>
+        /// Validator for the <see cref="DbLookup"/> transformation.
+        /// </summary>
+
+        public class Validator : AbstractValidator<DbLookup>
+        {
+            /// <summary>
+            /// Validator for the <see cref="DbLookup"/> transformation.
+            /// </summary>
+
+            public Validator()
+            {
+                // checks to see that both sides of each mapping has a value
+                bool HaveDefinedValues( DbLookup transformation, IEnumerable<(string, string)> mappings, PropertyValidatorContext context )
+                {
+                    mappings ??= Enumerable.Empty<(string, string)>();
+
+                    foreach ( var (field, other) in mappings )
+                    {
+                        if ( field == null || other == null )
+                        {
+                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.NoNullElementsValidationMessage );
+                            return false;
+                        }
+
+                        if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( other ) )
+                        {
+                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.NoWhiteSpaceElementsValidationMessage );
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                RuleFor( _ => _.ConnectionInfo ).NotNull();
+                RuleFor( _ => _.Input ).NotNull().Must( HaveDefinedValues );
+                RuleFor( _ => _.Output ).NotNull().Must( HaveDefinedValues );
+                RuleFor( _ => _.QueryMultipleRecordEvent ).NotNull();
+                RuleFor( _ => _.QueryZeroRecordEvent ).NotNull();
+                RuleFor( _ => _.Sql ).NotNull().NotWhiteSpace();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbLookup.cs
+++ b/src/Dataflows/Transformations/DbLookup.cs
@@ -35,6 +35,7 @@ namespace Shipwright.Dataflows.Transformations
 
         /// <summary>
         /// Collection of fields that are output by the query and their query result column names.
+        /// Column names are case sensitive.
         /// </summary>
 
         public ICollection<(string field, string column)> Output { get; init; } = new List<(string, string)>();
@@ -58,5 +59,14 @@ namespace Shipwright.Dataflows.Transformations
         /// </summary>
 
         public FailureEventSetting QueryMultipleRecordEvent { get; init; } = new FailureEventSetting();
+
+        /// <summary>
+        /// Whether to cache query results in memory.
+        /// Defaults to false.
+        /// Caching is only recommended when the same parameter values will be queried repeatedly.
+        /// This can increase performance at the cost of memory pressure.
+        /// </summary>
+
+        public bool CacheResults { get; set; }
     }
 }

--- a/src/Dataflows/Transformations/DbLookup.cs
+++ b/src/Dataflows/Transformations/DbLookup.cs
@@ -1,0 +1,62 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Databases;
+using System.Collections.Generic;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    /// <summary>
+    /// Transformation that performs a database lookup.
+    /// Output mapping will be performed only when the query yields exactly one record.
+    /// </summary>
+
+    public partial record DbLookup : Transformation
+    {
+        /// <summary>
+        /// Connection information for the database in which to perform the lookup.
+        /// </summary>
+
+        public DbConnectionInfo ConnectionInfo { get; init; } = null!;
+
+        /// <summary>
+        /// Parameterized query to use for lookup.
+        /// </summary>
+
+        public string Sql { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Collection of fields participating in the query and their query parameter names.
+        /// </summary>
+
+        public ICollection<(string field, string parameter)> Input { get; init; } = new List<(string, string)>();
+
+        /// <summary>
+        /// Collection of fields that are output by the query and their query result column names.
+        /// </summary>
+
+        public ICollection<(string field, string column)> Output { get; init; } = new List<(string, string)>();
+
+        /// <summary>
+        /// Defines a delegate for generating an event message for lookup failures.
+        /// </summary>
+        /// <param name="count">Number of matching records.</param>
+        /// <returns>A formatted event message.</returns>
+
+        public delegate string FailureEventMessageDelegate( int count );
+
+        /// <summary>
+        /// Setting that defines the event logged when the query returns no results.
+        /// </summary>
+
+        public FailureEventSetting QueryZeroRecordEvent { get; init; } = new FailureEventSetting();
+
+        /// <summary>
+        /// Setting that defined the event logged when the query returns multiple results.
+        /// </summary>
+
+        public FailureEventSetting QueryMultipleRecordEvent { get; init; } = new FailureEventSetting();
+    }
+}

--- a/src/Resources/CoreErrorMessages.Designer.cs
+++ b/src/Resources/CoreErrorMessages.Designer.cs
@@ -61,6 +61,15 @@ namespace Shipwright.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Database query lookup failed. The query returned {0} matching records..
+        /// </summary>
+        public static string DbLookupFailureMessage {
+            get {
+                return ResourceManager.GetString("DbLookupFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Required value is missing from the field [{0}].
         /// </summary>
         public static string MissingRequiredFieldValue {

--- a/src/Resources/CoreErrorMessages.resx
+++ b/src/Resources/CoreErrorMessages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DbLookupFailureMessage" xml:space="preserve">
+    <value>Database query lookup failed. The query returned {0} matching records.</value>
+  </data>
   <data name="MissingRequiredFieldValue" xml:space="preserve">
     <value>Required value is missing from the field [{0}]</value>
   </data>

--- a/src/Services/Caching/AsyncCache.cs
+++ b/src/Services/Caching/AsyncCache.cs
@@ -1,0 +1,36 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Nito.AsyncEx;
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Shipwright.Services.Caching
+{
+    /// <summary>
+    /// Thread-safe cache for values that must be obtained asynchronously.
+    /// </summary>
+    /// <typeparam name="TKey">Type of the cache key.</typeparam>
+    /// <typeparam name="TValue">Type of the cached value.</typeparam>
+
+    public class AsyncCache<TKey, TValue> where TKey : notnull
+    {
+        private readonly ConcurrentDictionary<TKey, AsyncLazy<TValue>> cache = new ConcurrentDictionary<TKey, AsyncLazy<TValue>>();
+
+        /// <summary>
+        /// Adds a key/value pair to the cache by using the given asynchronous function if the key
+        /// does not already exist.
+        /// </summary>
+        /// <param name="key">Key of the item to return.</param>
+        /// <param name="factory">Factory method to use for obtaining a new value.</param>
+        /// <returns>The value for the key. This will either be the existing value (if one exists) or
+        /// a new value created by the factory method.
+        /// </returns>
+
+        public virtual async Task<TValue> GetOrAdd( TKey key, Func<TKey, Task<TValue>> factory ) =>
+            await cache.GetOrAdd( key, key => new AsyncLazy<TValue>( () => factory.Invoke( key ) ) );
+    }
+}

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="FluentValidation" Version="9.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-rc.2.20475.5" />
   </ItemGroup>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.2.4</Version>
+    <Version>1.0.0-preview.3</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -38,7 +38,9 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
     <PackageReference Include="FluentValidation" Version="9.2.0" />
+    <PackageReference Include="Identifiable" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Databases/FakeConnectionInfo.cs
+++ b/test/Databases/FakeConnectionInfo.cs
@@ -1,0 +1,18 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+
+namespace Shipwright.Databases
+{
+    /// <summary>
+    /// Fake database connection information.
+    /// </summary>
+
+    public record FakeConnectionInfo : DbConnectionInfo
+    {
+        public Guid Id { get; init; } = Guid.NewGuid();
+    }
+}

--- a/test/Databases/Internal/CancellationDecoratorTests.cs
+++ b/test/Databases/Internal/CancellationDecoratorTests.cs
@@ -1,0 +1,68 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Databases.Internal
+{
+    public class CancellationDecoratorTests
+    {
+        private IDbConnectionBuilder<FakeConnectionInfo> inner;
+        private IDbConnectionBuilder<FakeConnectionInfo> instance() => new CancellationDecorator<FakeConnectionInfo>( inner );
+        private readonly Mock<IDbConnectionBuilder<FakeConnectionInfo>> mockInner;
+
+        public CancellationDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+        }
+
+        public class Constructor : CancellationDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+        }
+
+        public class Execute : CancellationDecoratorTests
+        {
+            private FakeConnectionInfo connectionInfo = new FakeConnectionInfo();
+            private CancellationToken cancellationToken;
+            private Task<IDbConnectionFactory> method() => instance().Build( connectionInfo, cancellationToken );
+
+            [Fact]
+            public async Task requires_connectionInfo()
+            {
+                connectionInfo = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( connectionInfo ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_canceled()
+            {
+                cancellationToken = new CancellationToken( true );
+                await Assert.ThrowsAsync<OperationCanceledException>( method );
+            }
+
+            [Fact]
+            public async Task awaits_inner_builder_when_not_canceled()
+            {
+                cancellationToken = new CancellationToken( false );
+
+                var expected = Mockery.Of<IDbConnectionFactory>();
+                mockInner.Setup( _ => _.Build( connectionInfo, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Same( expected, actual );
+            }
+        }
+    }
+}

--- a/test/Databases/Internal/DbConnectionDispatcherTests.cs
+++ b/test/Databases/Internal/DbConnectionDispatcherTests.cs
@@ -1,0 +1,75 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Databases.Internal
+{
+    public class DbConnectionDispatcherTests
+    {
+        private IServiceProvider serviceProvider;
+        private IDbConnectionDispatcher instance() => new DbConnectionDispatcher( serviceProvider );
+
+        private readonly Mock<IServiceProvider> mockServiceProvider;
+
+        public DbConnectionDispatcherTests()
+        {
+            mockServiceProvider = Mockery.Of( out serviceProvider );
+        }
+
+        public class Constructor : DbConnectionDispatcherTests
+        {
+            [Fact]
+            public void requires_serviceProvider()
+            {
+                serviceProvider = null!;
+                Assert.Throws<ArgumentNullException>( nameof( serviceProvider ), instance );
+            }
+        }
+
+        public class Build : DbConnectionDispatcherTests
+        {
+            private DbConnectionInfo connectionInfo = new FakeConnectionInfo();
+            private CancellationToken cancellationToken;
+            private Task<IDbConnectionFactory> method() => instance().Build( connectionInfo, cancellationToken );
+
+            [Fact]
+            public async Task requires_command()
+            {
+                connectionInfo = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( connectionInfo ), method );
+            }
+
+            [Fact]
+            public async Task throws_when_no_builder_found()
+            {
+                var builderType = typeof( IDbConnectionBuilder<FakeConnectionInfo> );
+                mockServiceProvider.Setup( _ => _.GetService( builderType ) ).Returns( null );
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>( method );
+                Assert.Equal( string.Format( Resources.CoreErrorMessages.MissingRequiredImplementation, builderType ), ex.Message );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_awaited_result_from_inner_handler( bool canceled )
+            {
+                var expected = Mockery.Of<IDbConnectionFactory>();
+                cancellationToken = new CancellationToken( canceled );
+                var builderType = typeof( IDbConnectionBuilder<FakeConnectionInfo> );
+                var mockBuilder = Mockery.Of( out IDbConnectionBuilder<FakeConnectionInfo> handler );
+                mockServiceProvider.Setup( _ => _.GetService( builderType ) ).Returns( handler );
+                mockBuilder.Setup( _ => _.Build( (FakeConnectionInfo)connectionInfo, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Same( expected, actual );
+            }
+        }
+    }
+}

--- a/test/Databases/Internal/ValidationDecoratorTests.cs
+++ b/test/Databases/Internal/ValidationDecoratorTests.cs
@@ -1,0 +1,88 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using Moq;
+using Shipwright.Validation;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Shipwright.Databases.Internal
+{
+    public class ValidationDecoratorTests
+    {
+        private IDbConnectionBuilder<FakeConnectionInfo> inner;
+        private IValidationAdapter<FakeConnectionInfo> validator;
+        private IDbConnectionBuilder<FakeConnectionInfo> instance() => new ValidationDecorator<FakeConnectionInfo>( inner, validator );
+        private readonly Mock<IDbConnectionBuilder<FakeConnectionInfo>> mockInner;
+        private readonly Mock<IValidationAdapter<FakeConnectionInfo>> mockValidator;
+
+        public ValidationDecoratorTests()
+        {
+            mockInner = Mockery.Of( out inner );
+            mockValidator = Mockery.Of( out validator );
+        }
+
+        public class Constructor : ValidationDecoratorTests
+        {
+            [Fact]
+            public void requires_inner()
+            {
+                inner = null!;
+                Assert.Throws<ArgumentNullException>( nameof( inner ), instance );
+            }
+
+            [Fact]
+            public void requires_validator()
+            {
+                validator = null!;
+                Assert.Throws<ArgumentNullException>( nameof( validator ), instance );
+            }
+        }
+
+        public class Execute : ValidationDecoratorTests
+        {
+            private FakeConnectionInfo connectionInfo = new FakeConnectionInfo();
+            private CancellationToken cancellationToken;
+            private Task<IDbConnectionFactory> method() => instance().Build( connectionInfo, cancellationToken );
+
+            [Fact]
+            public async Task requires_connectionInfo()
+            {
+                connectionInfo = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( connectionInfo ), method );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task rethrows_when_validation_fails( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+                var expected = new ValidationException( Guid.NewGuid().ToString() );
+                mockValidator.Setup( _ => _.ValidateAndThrow( connectionInfo, cancellationToken ) ).ThrowsAsync( expected );
+                var actual = await Assert.ThrowsAsync<ValidationException>( method );
+                Assert.Equal( expected, actual );
+            }
+
+            [Theory]
+            [ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task awaits_inner_builder_when_validation_passes( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var expected = Mockery.Of<IDbConnectionFactory>();
+                mockValidator.Setup( _ => _.ValidateAndThrow( connectionInfo, cancellationToken ) ).Returns( Task.CompletedTask );
+                mockInner.Setup( _ => _.Build( connectionInfo, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                Assert.Same( expected, actual );
+
+                mockValidator.Verify( _ => _.ValidateAndThrow( connectionInfo, cancellationToken ), Times.Once() );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbLookupTests/CacheHandlerTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/CacheHandlerTests.cs
@@ -1,0 +1,102 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using Shipwright.Databases;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbLookup;
+
+namespace Shipwright.Dataflows.Transformations.DbLookupTests
+{
+    public class CacheHandlerTests
+    {
+        private DbLookup transformation = new DbLookup { CacheResults = true };
+        private readonly IDbConnectionFactory connectionFactory = Mockery.Of<IDbConnectionFactory>();
+        private CacheHandler instance() => mockHandler.Object;
+
+        private Mock<CacheHandler> mockHandler;
+
+        public CacheHandlerTests()
+        {
+            mockHandler = new Mock<CacheHandler>( MockBehavior.Loose, transformation, connectionFactory ) { CallBase = true };
+        }
+
+        public class GetMatches : CacheHandlerTests
+        {
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_same_result_on_subsequent_call_when_parameters_equal_and_caching_desired( bool canceled )
+            {
+                var fixture = new Fixture();
+                var cancellationToken = new CancellationToken( canceled );
+                var parameters = fixture.Create<Dictionary<string, string>>().ToDictionary( _ => _.Key, _ => (object)_.Value );
+                var expected = fixture.CreateMany<string>( 3 );
+
+                var capture = new List<IDictionary<string, object>>();
+                mockHandler.Setup( _ => _.GetMatchesEx( Capture.In( capture ), cancellationToken ) ).ReturnsAsync( expected );
+
+                var instance = base.instance();
+                var first = await instance.GetMatches( parameters, cancellationToken );
+                var second = await instance.GetMatches( new Dictionary<string, object>( parameters ), cancellationToken );
+
+                Assert.Same( expected, first );
+                Assert.Same( expected, second );
+                capture.Should().ContainSingle().Subject.Should().BeSameAs( parameters );
+                mockHandler.Verify( _ => _.GetMatchesEx( It.IsAny<IDictionary<string, object>>(), cancellationToken ), Times.Once() );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_different_result_on_subsequent_call_when_parameters_equal_and_caching_desired( bool canceled )
+            {
+                var fixture = new Fixture();
+                var cancellationToken = new CancellationToken( canceled );
+                var parameters1 = fixture.Create<Dictionary<string, string>>().ToDictionary( _ => _.Key, _ => (object)_.Value.ToLowerInvariant() );
+                var parameters2 = parameters1.ToDictionary( _ => _.Key, _ => (object)_.Value.ToString().ToUpperInvariant() );
+                var expected1 = fixture.CreateMany<string>( 3 );
+                var expected2 = fixture.CreateMany<string>( 3 );
+
+                mockHandler.Setup( _ => _.GetMatchesEx( parameters1, cancellationToken ) ).ReturnsAsync( expected1 );
+                mockHandler.Setup( _ => _.GetMatchesEx( parameters2, cancellationToken ) ).ReturnsAsync( expected2 );
+
+                var instance = base.instance();
+                var first = await instance.GetMatches( parameters1, cancellationToken );
+                var second = await instance.GetMatches( parameters2, cancellationToken );
+
+                Assert.Same( expected1, first );
+                Assert.Same( expected2, second );
+                mockHandler.Verify( _ => _.GetMatchesEx( It.IsAny<IDictionary<string, object>>(), cancellationToken ), Times.Exactly( 2 ) );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_same_result_on_subsequent_call_when_parameters_equal_and_caching_not_desired( bool canceled )
+            {
+                // note: must reset the mock to change transformation values
+                transformation = transformation with { CacheResults = false };
+                mockHandler = new Mock<CacheHandler>( MockBehavior.Loose, transformation, connectionFactory ) { CallBase = true };
+
+                var fixture = new Fixture();
+                var cancellationToken = new CancellationToken( canceled );
+                var parameters = fixture.Create<Dictionary<string, string>>().ToDictionary( _ => _.Key, _ => (object)_.Value );
+                var expected = new[] { fixture.CreateMany<string>( 3 ), fixture.CreateMany<string>( 3 ) };
+
+                var index = 0;
+                mockHandler.Setup( _ => _.GetMatchesEx( parameters, cancellationToken ) ).ReturnsAsync( () => expected[index++] );
+
+                var instance = base.instance();
+                var first = await instance.GetMatches( parameters, cancellationToken );
+                var second = await instance.GetMatches( parameters, cancellationToken );
+
+                Assert.Same( expected[0], first );
+                Assert.Same( expected[1], second );
+                mockHandler.Verify( _ => _.GetMatchesEx( parameters, cancellationToken ), Times.Exactly( 2 ) );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbLookupTests/FactoryTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/FactoryTests.cs
@@ -1,0 +1,82 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using Shipwright.Databases;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbLookup;
+
+namespace Shipwright.Dataflows.Transformations.DbLookupTests
+{
+    public class FactoryTests
+    {
+        private IDbConnectionDispatcher dispatcher;
+        private ITransformationFactory<DbLookup> instance() => new Factory( dispatcher );
+
+        private readonly Mock<IDbConnectionDispatcher> mockDispatcher;
+
+        public FactoryTests()
+        {
+            mockDispatcher = Mockery.Of( out dispatcher );
+        }
+
+        public class Constructor : FactoryTests
+        {
+            [Fact]
+            public void requires_dispatcher()
+            {
+                dispatcher = null!;
+                Assert.Throws<ArgumentNullException>( nameof( dispatcher ), instance );
+            }
+        }
+
+        public class Create : FactoryTests
+        {
+            private DbLookup transformation = new DbLookup();
+            private CancellationToken cancellationToken;
+            private Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
+
+            [Fact]
+            public async Task requires_transformation()
+            {
+                transformation = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_default_handler_when_caching_disabled( bool canceled )
+            {
+                transformation = transformation with { CacheResults = false };
+                cancellationToken = new CancellationToken( canceled );
+
+                var connectionFactory = Mockery.Of<IDbConnectionFactory>();
+                mockDispatcher.Setup( _ => _.Build( transformation.ConnectionInfo, cancellationToken ) ).ReturnsAsync( connectionFactory );
+
+                var actual = await method();
+                var typed = Assert.IsType<Handler>( actual );
+                Assert.Same( transformation, typed.transformation );
+                Assert.Same( connectionFactory, typed.connectionFactory );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task returns_caching_handler_when_caching_enabled( bool canceled )
+            {
+                transformation = transformation with { CacheResults = true };
+                cancellationToken = new CancellationToken( canceled );
+
+                var connectionFactory = Mockery.Of<IDbConnectionFactory>();
+                mockDispatcher.Setup( _ => _.Build( transformation.ConnectionInfo, cancellationToken ) ).ReturnsAsync( connectionFactory );
+
+                var actual = await method();
+                var typed = Assert.IsType<CacheHandler>( actual );
+                Assert.Same( transformation, typed.transformation );
+                Assert.Same( connectionFactory, typed.connectionFactory );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbLookupTests/FailureEventSettingValidatorTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/FailureEventSettingValidatorTests.cs
@@ -1,0 +1,26 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using System;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbLookup;
+
+namespace Shipwright.Dataflows.Transformations.DbLookupTests
+{
+    internal class FailureEventSettingValidatorTests
+    {
+        private readonly IValidator<FailureEventSetting> validator = new Validator.FailureEventSettingValidator();
+
+        public class FailureEventMessage : FailureEventSettingValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.FailureEventMessage, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.FailureEventMessage, _ => Guid.NewGuid().ToString() );
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
@@ -1,0 +1,270 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbLookup;
+
+namespace Shipwright.Dataflows.Transformations.DbLookupTests
+{
+    public class HandlerTests
+    {
+        private DbLookup transformation = new DbLookup();
+        private IDbConnectionFactory connectionFactory = Mockery.Of<IDbConnectionFactory>();
+        private ITransformationHandler instance() => new Handler( transformation, connectionFactory );
+
+        public class Constructor : HandlerTests
+        {
+            [Fact]
+            public void requires_transformation()
+            {
+                transformation = null!;
+                Assert.Throws<ArgumentNullException>( nameof( transformation ), instance );
+            }
+
+            [Fact]
+            public void requires_connectionFactory()
+            {
+                connectionFactory = null!;
+                Assert.Throws<ArgumentNullException>( nameof( connectionFactory ), instance );
+            }
+        }
+
+        public class MapInputs : HandlerTests
+        {
+            private readonly Record record = FakeRecord.Create();
+            private IDictionary<string, object> method() => (instance() as Handler).MapInputs( record );
+
+            [Fact]
+            public void returns_dictionary_with_values_for_all_input_parameters()
+            {
+                transformation.Input.Clear();
+
+                var expected = new Dictionary<string, object>();
+                var fixture = new Fixture();
+
+                // add parameter with a defined field value
+                var first = fixture.Create<(string field, string parameter)>();
+                record.Data[first.field] = expected[first.parameter] = Guid.NewGuid();
+                transformation.Input.Add( first );
+
+                // add parameter with a null field value
+                var second = fixture.Create<(string field, string parameter)>();
+                record.Data[second.field] = expected[second.parameter] = null;
+                transformation.Input.Add( second );
+
+                // add parameter with a missing field value
+                var third = fixture.Create<(string field, string parameter)>();
+                record.Data.Remove( third.field );
+                expected[third.parameter] = null;
+                transformation.Input.Add( third );
+
+                var actual = method();
+                actual.Should().BeEquivalentTo( expected );
+            }
+        }
+
+        public class TryGetResult : HandlerTests
+        {
+            private readonly Record record = FakeRecord.Create();
+            private IEnumerable<dynamic> matches;
+            private object parameters;
+            private IDictionary<string, object> result;
+            private bool method() => (instance() as Handler).TryGetResult( record, matches, parameters, out result );
+
+            private readonly Fixture fixture = new Fixture();
+
+            [Fact]
+            public void returns_false_and_adds_event_when_no_matches()
+            {
+                matches = Array.Empty<dynamic>();
+                parameters = fixture.Create<object>();
+
+                var actual = method();
+                Assert.False( actual );
+                Assert.Null( result );
+
+                var settings = transformation.QueryZeroRecordEvent;
+                var expected = new LogEvent
+                {
+                    IsFatal = settings.IsFatal,
+                    Level = settings.Level,
+                    Description = settings.FailureEventMessage( 0 ),
+                    Value = parameters
+                };
+
+                record.Events.Should().ContainSingle().Subject.Should().BeEquivalentTo( expected );
+            }
+
+            [Fact]
+            public void returns_false_and_adds_event_when_multiple_matches()
+            {
+                matches = fixture.CreateMany<Dictionary<string, object>>( 2 );
+                parameters = fixture.Create<object>();
+
+                var actual = method();
+                Assert.False( actual );
+                Assert.Same( matches.First(), result );
+
+                var settings = transformation.QueryMultipleRecordEvent;
+                var expected = new LogEvent
+                {
+                    IsFatal = settings.IsFatal,
+                    Level = settings.Level,
+                    Description = settings.FailureEventMessage( 2 ),
+                    Value = parameters
+                };
+
+                record.Events.Should().ContainSingle().Subject.Should().BeEquivalentTo( expected );
+            }
+
+            [Fact]
+            public void returns_true_when_single_match()
+            {
+                matches = fixture.CreateMany<Dictionary<string, object>>( 1 );
+                parameters = fixture.Create<object>();
+
+                var actual = method();
+                Assert.True( actual );
+                Assert.Same( matches.Single(), result );
+
+                record.Events.Should().BeEmpty();
+            }
+        }
+
+        public class MapResult : HandlerTests
+        {
+            private readonly Record record = FakeRecord.Create();
+            private readonly IDictionary<string, object> result = new Dictionary<string, object>();
+
+            private void method() => (instance() as Handler).MapResult( record, result );
+
+            [Fact]
+            public void overrites_existing_field_when_column_present()
+            {
+                var fixture = new Fixture();
+                transformation = transformation with { Output = new List<(string, string)>( fixture.CreateMany<(string, string)>( 3 ) ) };
+
+                var expected = new Dictionary<string, object>( record.Data );
+
+                foreach ( var (field, column) in transformation.Output )
+                {
+                    record.Data[field] = Guid.NewGuid();
+                    expected[field] = result[column] = Guid.NewGuid();
+                }
+
+                method();
+                record.Data.Should().BeEquivalentTo( expected );
+            }
+
+            [Fact]
+            public void creates_field_when_column_present()
+            {
+                var fixture = new Fixture();
+                transformation = transformation with { Output = new List<(string, string)>( fixture.CreateMany<(string, string)>( 3 ) ) };
+
+                var expected = new Dictionary<string, object>( record.Data );
+
+                foreach ( var (field, column) in transformation.Output )
+                {
+                    record.Data.Remove( field );
+                    expected[field] = result[column] = Guid.NewGuid();
+                }
+
+                method();
+                record.Data.Should().BeEquivalentTo( expected );
+            }
+
+            [Fact]
+            public void ignores_field_when_column_missing()
+            {
+                var fixture = new Fixture();
+                transformation = transformation with { Output = new List<(string, string)>( fixture.CreateMany<(string, string)>( 3 ) ) };
+
+                var expected = new Dictionary<string, object>( record.Data );
+
+                foreach ( var (field, column) in transformation.Output )
+                {
+                    expected[field] = record.Data[field] = Guid.NewGuid();
+                    result.Remove( column );
+                }
+
+                method();
+                record.Data.Should().BeEquivalentTo( expected );
+            }
+        }
+
+        public class Transform : HandlerTests
+        {
+            private new ITransformationHandler instance() => mockHandler.Object;
+
+            private readonly Mock<Handler> mockHandler;
+            private Record record = FakeRecord.Create();
+            private CancellationToken cancellationToken;
+
+            private Task method() => instance().Transform( record, cancellationToken );
+
+            public Transform()
+            {
+                mockHandler = new Mock<Handler>( MockBehavior.Loose, transformation, connectionFactory ) { CallBase = true };
+            }
+
+            [Fact]
+            public async Task requires_record()
+            {
+                record = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task maps_query_results_when_matches_found( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var fixture = new Fixture();
+                var parameters = new Dictionary<string, object>();
+                var matches = fixture.CreateMany<IDictionary<string, object>>( 1 );
+                var result = fixture.Create<IDictionary<string, object>>();
+
+                var sequence = new MockSequence();
+                mockHandler.InSequence( sequence ).Setup( _ => _.MapInputs( record ) ).Returns( parameters );
+                mockHandler.InSequence( sequence ).Setup( _ => _.GetMatches( parameters, cancellationToken ) ).ReturnsAsync( matches );
+                mockHandler.InSequence( sequence ).Setup( _ => _.TryGetResult( record, matches, parameters, out result ) ).Returns( true );
+                mockHandler.InSequence( sequence ).Setup( _ => _.MapResult( record, result ) );
+
+                await method();
+                mockHandler.Verify( _ => _.MapResult( record, result ), Times.Once() );
+            }
+
+            [Theory, ClassData( typeof( Cases.BooleanCases ) )]
+            public async Task noop_when_result_not_matched( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var fixture = new Fixture();
+                var parameters = new Dictionary<string, object>();
+                var matches = fixture.CreateMany<IDictionary<string, object>>( 3 );
+                var result = fixture.Create<IDictionary<string, object>>();
+
+                var sequence = new MockSequence();
+                mockHandler.InSequence( sequence ).Setup( _ => _.MapInputs( record ) ).Returns( parameters );
+                mockHandler.InSequence( sequence ).Setup( _ => _.GetMatches( parameters, cancellationToken ) ).ReturnsAsync( matches );
+                mockHandler.InSequence( sequence ).Setup( _ => _.TryGetResult( record, matches, parameters, out result ) ).Returns( false );
+
+                await method();
+                mockHandler.Verify( _ => _.TryGetResult( record, matches, parameters, out result ), Times.Once() );
+                mockHandler.Verify( _ => _.MapResult( record, result ), Times.Never() );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
@@ -150,7 +150,7 @@ namespace Shipwright.Dataflows.Transformations.DbLookupTests
             private void method() => (instance() as Handler).MapResult( record, result );
 
             [Fact]
-            public void overrites_existing_field_when_column_present()
+            public void overwrites_existing_field_when_column_present()
             {
                 var fixture = new Fixture();
                 transformation = transformation with { Output = new List<(string, string)>( fixture.CreateMany<(string, string)>( 3 ) ) };

--- a/test/Dataflows/Transformations/DbLookupTests/ValidatorTests.cs
+++ b/test/Dataflows/Transformations/DbLookupTests/ValidatorTests.cs
@@ -1,0 +1,97 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using AutoFixture.Xunit2;
+using FluentValidation;
+using Shipwright.Databases;
+using System.Collections.Generic;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbLookup;
+
+namespace Shipwright.Dataflows.Transformations.DbLookupTests
+{
+    public class ValidatorTests
+    {
+        private readonly IValidator<DbLookup> validator = new Validator();
+        private readonly Fixture fixture = new Fixture();
+
+        public class ConnectionInfo : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.ConnectionInfo, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.ConnectionInfo, new FakeConnectionInfo() );
+        }
+
+        public class Input : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Input, null );
+
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_any_field_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Input, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (value, fixture.Create<string>()) } );
+
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_any_parameter_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Input, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (fixture.Create<string>(), value) } );
+
+            [Fact]
+            public void valid_when_empty() => validator.ValidWhen( _ => _.Input, new List<(string, string)>() );
+
+            [Fact]
+            public void valid_when_all_elements_given() => validator.ValidWhen( _ => _.Input, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) );
+        }
+
+        public class Output : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Output, null );
+
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_any_field_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (value, fixture.Create<string>()) } );
+
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_any_column_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (fixture.Create<string>(), value) } );
+
+            [Fact]
+            public void valid_when_empty() => validator.ValidWhen( _ => _.Output, new List<(string, string)>() );
+
+            [Fact]
+            public void valid_when_all_elements_given() => validator.ValidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) );
+        }
+
+        public class QueryMultipleRecordEvent : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.QueryMultipleRecordEvent, null );
+
+            [Fact]
+            public void has_child_validator_when_given() => validator.HasChildValidator( _ => _.QueryMultipleRecordEvent, typeof( Validator.FailureEventSettingValidator ) );
+        }
+
+        public class QueryZeroRecordEvent : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.QueryZeroRecordEvent, null );
+
+            [Fact]
+            public void has_child_validator_when_given() => validator.HasChildValidator( _ => _.QueryZeroRecordEvent, typeof( Validator.FailureEventSettingValidator ) );
+        }
+
+        public class Sql : ValidatorTests
+        {
+            [Theory, ClassData( typeof( Cases.NullAndWhiteSpaceCases ) )]
+            public void invalid_when_null_or_whitespace( string value ) => validator.InvalidWhen( _ => _.Sql, value );
+
+            [Theory, AutoData]
+            public void valid_when_given( string value ) => validator.ValidWhen( _ => _.Sql, value );
+        }
+    }
+}


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1465
---
### Problem
As an ETL developer, I want to be add or replace values in a record based on the results of a database query executed with parameters from other fields in the record.

Functionality required from previous generations:

- Option to cache results to avoid repetitive database calls when the result is already known. This should not be the default behavior.
- Option to have a zero-result lookup be valid.

New functionality that should be included:

- Ability to specify distinct event messages for zero- or multi-result lookups. This will assist in creating more meaningful message for users when there is an issue with a field.

### Solution
- Added ability to generate database connections.
- Added DbLookup transformation that has:
  - Distinct customizable event behaviors for zero or multiple results. These can be used to customize both the logged event message, as well as controlling whether they are fatal events.
  - A caching option with it own handler.

### Additional Notes
No specific database implementations exist in the core library. Each database will have its own package to minimize dependency churn in the core project.