### PR TITLE
NET-1468: DbUpsert transformation

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.3</Version>
+    <Version>1.0.0-preview.4</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4</Version>
+    <Version>1.0.0-preview.4.1</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Dataflows/Transformations/DbUpsert.ColumnType.cs
+++ b/src/Dataflows/Transformations/DbUpsert.ColumnType.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Type of participation a column has in an upsert operation.
+        /// </summary>
+
+        public enum ColumnType
+        {
+            /// <summary>
+            /// Column is part of the record key used to determine uniqueness.
+            /// Column value is inserted on new records, but never updated.
+            /// </summary>
+
+            Key,
+
+            /// <summary>
+            /// Column value is inserted on new records, but never updated.
+            /// </summary>
+
+            Insert,
+
+            /// <summary>
+            /// Column value is inserted on new records and updated on existing records when a
+            /// change is detected.
+            /// </summary>
+
+            Upsert,
+
+            /// <summary>
+            /// Column value is updated only when a change is detected in <see cref="Upsert"/>
+            /// columns. This is useful for non-deterministic fields like timestamps where you want
+            /// to write a new value only when an update statement is issued.
+            /// </summary>
+
+            Trigger,
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.ColumnValue.cs
+++ b/src/Dataflows/Transformations/DbUpsert.ColumnValue.cs
@@ -1,0 +1,19 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+
+#pragma warning disable CS1591
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Defines a column, its parameter name, and current value.
+        /// </summary>
+
+        public record ColumnValue( string Column, string Parameter, object Value );
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.Factory.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Factory.cs
@@ -1,0 +1,45 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Databases;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Factory for the <see cref="DbUpsert"/> transformation.
+        /// </summary>
+
+        public class Factory : ITransformationFactory<DbUpsert>
+        {
+            private readonly IDbConnectionDispatcher connectionDispatcher;
+
+            /// <summary>
+            /// Factory for the <see cref="DbUpsert"/> transformation.
+            /// </summary>
+
+            public Factory( IDbConnectionDispatcher connectionDispatcher )
+            {
+                this.connectionDispatcher = connectionDispatcher ?? throw new ArgumentNullException( nameof( connectionDispatcher ) );
+            }
+
+            /// <summary>
+            /// Creates a handler for the given transformation.
+            /// </summary>
+
+            public async Task<ITransformationHandler> Create( DbUpsert transformation, CancellationToken cancellationToken )
+            {
+                if ( transformation == null ) throw new ArgumentNullException( nameof( transformation ) );
+
+                var connectionFactory = await connectionDispatcher.Build( transformation.ConnectionInfo, cancellationToken );
+                return new Handler( transformation, connectionFactory );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.Handler.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Handler.cs
@@ -188,10 +188,7 @@ namespace Shipwright.Dataflows.Transformations
 
                 foreach ( var (field, column, type) in transformation.Mappings )
                 {
-                    if ( type != ColumnType.Trigger )
-                    {
-                        map[column] = new ColumnValue( column, $"p{++index}", record.Data.TryGetValue( field, out var value ) ? value : null! );
-                    }
+                    map[column] = new ColumnValue( column, $"p{++index}", record.Data.TryGetValue( field, out var value ) ? value : null! );
                 }
 
                 parameters = map.Values.ToDictionary( _ => _.Parameter, _ => _.Value );

--- a/src/Dataflows/Transformations/DbUpsert.Handler.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Handler.cs
@@ -1,0 +1,300 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Dapper;
+using Identifiable;
+using Nito.AsyncEx;
+using Shipwright.Databases;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Handler for <see cref="DbUpsert"/> transformations.
+        /// </summary>
+
+        public class Handler : TransformationHandler
+        {
+            internal DbUpsert transformation;
+            internal IDbConnectionFactory connectionFactory;
+
+            /// <summary>
+            /// Handler for <see cref="DbUpsert"/> transformations.
+            /// </summary>
+
+            public Handler( DbUpsert transformation, IDbConnectionFactory connectionFactory )
+            {
+                this.transformation = transformation ?? throw new ArgumentNullException( nameof( transformation ) );
+                this.connectionFactory = connectionFactory ?? throw new ArgumentNullException( nameof( connectionFactory ) );
+            }
+
+            /// <summary>
+            /// Collection of semaphores for avoiding concurrent inserts/updates to the same key.
+            /// </summary>
+
+            private readonly ConcurrentDictionary<Guid, SemaphoreSlim> semaphores = new ConcurrentDictionary<Guid, SemaphoreSlim>();
+
+            /// <summary>
+            /// Namespace for building semaphore keys.
+            /// </summary>
+
+            private Guid @namespace = NamedGuid.Compute( NamedGuidAlgorithm.SHA1, Guid.Empty, "ns://seas.technology/cache" );
+
+            /// <summary>
+            /// Releases resources held by the handler.
+            /// </summary>
+
+            protected override ValueTask DisposeAsyncCore()
+            {
+                foreach ( var item in semaphores )
+                {
+                    item.Value.Dispose();
+                }
+
+                return base.DisposeAsyncCore();
+            }
+
+            /// <summary>
+            /// Builds the appropriate SQL statement for obtaining the current values of the linked
+            /// database record.
+            /// </summary>
+
+            public virtual string BuildSelectSql( Record record, out IDictionary<string, object> keys )
+            {
+                var index = 0;
+                var keyMap = new Dictionary<string, ColumnValue>();
+                var columns = new List<string>();
+
+                foreach ( var (field, column, type) in transformation.Mappings )
+                {
+                    if ( type == ColumnType.Key )
+                    {
+                        keyMap[column] = new ColumnValue( column, $"p{++index}", record.Data.TryGetValue( field, out var value ) ? value : null! );
+                    }
+
+                    if ( type == ColumnType.Upsert )
+                    {
+                        columns.Add( column );
+                    }
+                }
+
+                keys = keyMap.Values.ToDictionary( _ => _.Parameter, _ => _.Value );
+                return transformation.SqlHelper.BuildSelectSql( transformation.Table, columns, keyMap.Values );
+            }
+
+            /// <summary>
+            /// Obtains a lock on the specified key value. This prevents deadlocks if the same key values
+            /// appear in the dataflow more than once.
+            /// </summary>
+            /// <param name="keys">Record key on which to lock.</param>
+            /// <param name="cancellationToken">Cancellation token.</param>
+            /// <returns>A reference to a lock that releases when it is disposed.</returns>
+
+            public virtual async Task<IDisposable> Lock( IDictionary<string, object> keys, CancellationToken cancellationToken )
+            {
+                var name = JsonSerializer.Serialize( keys );
+                var id = NamedGuid.Compute( NamedGuidAlgorithm.SHA1, @namespace, name );
+                var semaphore = semaphores.GetOrAdd( id, _ => new SemaphoreSlim( 1, 1 ) );
+
+                return await semaphore.LockAsync( cancellationToken );
+            }
+
+            /// <summary>
+            /// Executes the given query statement.
+            /// </summary>
+            /// <param name="sql">SQL query to execute.</param>
+            /// <param name="parameters">Query parameters.</param>
+            /// <param name="cancellationToken">Cancellation token.</param>
+            /// <returns>The collection of query results.</returns>
+
+            public virtual async Task<IEnumerable<dynamic>> Query( string sql, IDictionary<string, object> parameters, CancellationToken cancellationToken )
+            {
+                var command = new CommandDefinition( sql, parameters: parameters, cancellationToken: cancellationToken );
+                using var connection = connectionFactory.Create();
+
+                return await connection.QueryAsync( command );
+            }
+
+            /// <summary>
+            /// Attempts to isolate a single result in the matches and outputs it.
+            /// If multiple records are found, a failure event will be logged on the record.
+            /// </summary>
+            /// <param name="record">Dataflow record.</param>
+            /// <param name="sql">SQL statement that produced the matches.</param>
+            /// <param name="matches">Query matches.</param>
+            /// <param name="keys">Key parameters that produced the error.</param>
+            /// <param name="current">A single matching record or null if a record was not found.</param>
+            /// <returns>
+            /// True if zero or one matches were found in the results.
+            /// False if multiple matches were found.
+            /// </returns>
+
+            public virtual bool TryGetCurrent( Record record, string sql, IEnumerable<dynamic> matches, IDictionary<string, object> keys, out IDictionary<string, object>? current )
+            {
+                var count = matches.Count();
+                current = matches.FirstOrDefault();
+
+                if ( count > 1 )
+                {
+                    record.Events.Add( new LogEvent
+                    {
+                        IsFatal = true,
+                        Level = Microsoft.Extensions.Logging.LogLevel.Error,
+                        Description = transformation.DuplicateKeyEventMessage( count ),
+                        Value = new { sql, keys },
+                    } );
+                }
+
+                return count <= 1;
+            }
+
+            /// <summary>
+            /// Executes the given SQL statement.
+            /// </summary>
+            /// <param name="sql">SQL statement to execute.</param>
+            /// <param name="parameters">Statement parameters.</param>
+            /// <param name="cancellationToken">Cancellation token.</param>
+
+            public async Task Execute( string sql, IDictionary<string, object> parameters, CancellationToken cancellationToken )
+            {
+                var command = new CommandDefinition( sql, parameters: parameters, cancellationToken: cancellationToken );
+                using var connection = connectionFactory.Create();
+
+                await connection.ExecuteAsync( command );
+            }
+
+            /// <summary>
+            /// Builds the SQL statement to perform a record insert.
+            /// </summary>
+            /// <param name="record">Dataflow record containing the field values.</param>
+            /// <param name="parameters">Parameters for the insert statement.</param>
+            /// <returns>The completed SQL statement.</returns>
+
+            public virtual string BuildInsertSql( Record record, out IDictionary<string, object> parameters )
+            {
+                var index = 0;
+                var map = new Dictionary<string, ColumnValue>();
+
+                foreach ( var (field, column, type) in transformation.Mappings )
+                {
+                    if ( type != ColumnType.Trigger )
+                    {
+                        map[column] = new ColumnValue( column, $"p{++index}", record.Data.TryGetValue( field, out var value ) ? value : null! );
+                    }
+                }
+
+                parameters = map.Values.ToDictionary( _ => _.Parameter, _ => _.Value );
+                return transformation.SqlHelper.BuildInsertSql( transformation.Table, map.Values );
+            }
+
+            private static bool IsEqual( object source, object comparer )
+            {
+                // handle array comparisons (e.g. MSSQL varbinary)
+                if ( source is IStructuralEquatable structural && structural.GetType().IsArray )
+                {
+                    return structural.Equals( comparer, StructuralComparisons.StructuralEqualityComparer );
+                }
+
+                // handle boolean/integer conversions
+                // this handles edge cases where boolean values are stored in integer fields
+                if ( source is bool boolSource && comparer is int intComparer )
+                {
+                    return (boolSource && intComparer == 1) || (!boolSource && intComparer == 0);
+                }
+
+                // handle typical comparisons
+                return Equals( source, comparer );
+            }
+
+            /// <summary>
+            /// Determines whether the incoming record differs from the current values in the database.
+            /// </summary>
+            /// <param name="record">Record containing the incoming values.</param>
+            /// <param name="current">Current database values.</param>
+            /// <param name="sql">The SQL statement to update the record.</param>
+            /// <param name="parameters">Parameters for the update statement.</param>
+            /// <returns>True if the database should be updated; otherwise false.</returns>
+
+            public virtual bool ShouldUpdate( Record record, IDictionary<string, object> current, out string sql, out IDictionary<string, object> parameters )
+            {
+                var index = 0;
+                var map = new Dictionary<string, ColumnValue>();
+                var updates = new Dictionary<string, ColumnValue>();
+                var triggers = new Dictionary<string, ColumnValue>();
+                var keys = new Dictionary<string, ColumnValue>();
+
+                ColumnValue extract( string field, string column ) =>
+                    new ColumnValue( column, $"p{++index}", record.Data.TryGetValue( field, out var value ) ? value : null! );
+
+                foreach ( var (field, column, type) in transformation.Mappings )
+                {
+                    if ( type == ColumnType.Key )
+                    {
+                        keys[column] = map[column] = extract( field, column );
+                    }
+
+                    if ( type == ColumnType.Trigger )
+                    {
+                        triggers[column] = map[column] = extract( field, column );
+                    }
+
+                    if ( type == ColumnType.Upsert )
+                    {
+                        var candidate = extract( field, column );
+                        var comparer = current.TryGetValue( column, out var value ) ? value : null!;
+
+                        if ( !IsEqual( candidate.Value, comparer ) )
+                        {
+                            updates[column] = map[column] = candidate;
+                        }
+                    }
+                }
+
+                parameters = map.Values.ToDictionary( _ => _.Parameter, _ => _.Value );
+                sql = transformation.SqlHelper.BuildUpdateSql( transformation.Table, updates.Values.Union( triggers.Values ), keys.Values );
+                return updates.Any();
+            }
+
+            /// <summary>
+            /// Compares record values to database values and inserts or updates records as needed.
+            /// </summary>
+
+            public override async Task Transform( Record record, CancellationToken cancellationToken )
+            {
+                if ( record == null ) throw new ArgumentNullException( nameof( record ) );
+
+                var select = BuildSelectSql( record, out var keys );
+
+                using ( await Lock( keys, cancellationToken ) )
+                {
+                    var matches = await Query( select, keys, cancellationToken );
+
+                    if ( TryGetCurrent( record, select, matches, keys, out var current ) )
+                    {
+                        if ( current == null )
+                        {
+                            var insert = BuildInsertSql( record, out var parameters );
+                            await Execute( insert, parameters, cancellationToken );
+                        }
+
+                        else if ( ShouldUpdate( record, current, out var update, out var parameters ) )
+                        {
+                            await Execute( update, parameters, cancellationToken );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.Handler.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Handler.cs
@@ -166,7 +166,7 @@ namespace Shipwright.Dataflows.Transformations
             /// <param name="parameters">Statement parameters.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
 
-            public async Task Execute( string sql, IDictionary<string, object> parameters, CancellationToken cancellationToken )
+            public virtual async Task Execute( string sql, IDictionary<string, object> parameters, CancellationToken cancellationToken )
             {
                 var command = new CommandDefinition( sql, parameters: parameters, cancellationToken: cancellationToken );
                 using var connection = connectionFactory.Create();

--- a/src/Dataflows/Transformations/DbUpsert.Helper.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Helper.cs
@@ -1,0 +1,101 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Defines a helper for building DBMS-specific SQL statements.
+        /// </summary>
+
+        public abstract class Helper
+        {
+            // helper method to escape sql server identifiers
+            private static string Quotename( string name ) => $"[{name.Replace( "]", "]]" )}]";
+
+            /// <summary>
+            /// Builds the SQL select statement to query a single existing record in the table.
+            /// </summary>
+            /// <param name="table">Name of the table from which to select.</param>
+            /// <param name="columnsToSelect">Columns to include in the select statement.</param>
+            /// <param name="keyMap">Key columns, parameter names, and current values for building conditional statements.</param>
+            /// <returns>The select statement to return a single record.</returns>
+            /// <remarks>Default implementation is for Microsoft SQL Server.</remarks>
+
+            public virtual string BuildSelectSql( string table, IEnumerable<string> columnsToSelect, IEnumerable<ColumnValue> keyMap )
+            {
+                var conditions = new List<string>();
+
+                foreach ( var (column, parameter, value) in keyMap )
+                {
+                    conditions.Add( $"{Quotename( column )} {(value == null ? "is null" : $"= @{parameter}")}" );
+                }
+
+                return $@"
+                    select {string.Join( ", ", columnsToSelect.Select( Quotename ) )}
+                    from {table}
+                    where {string.Join( " and ", conditions )};";
+            }
+
+            /// <summary>
+            /// Builds the SQL statement to insert a record with the given column mapping.
+            /// </summary>
+            /// <param name="table">Name of the table into which to insert.</param>
+            /// <param name="map">Insertable columns, parameter name, and current values to include in the insert statement.</param>
+            /// <returns>The insert statement to insert a single record.</returns>
+            /// <remarks>The default implementation is for Microsoft SQL Server.</remarks>
+
+            public virtual string BuildInsertSql( string table, IEnumerable<ColumnValue> map )
+            {
+                var columns = new List<string>();
+                var values = new List<string>();
+
+                foreach ( var (column, parameter, value) in map )
+                {
+                    columns.Add( Quotename( column ) );
+                    values.Add( $"@{parameter}" );
+                }
+
+                return $@"
+                    insert {table} ( {string.Join( ", ", columns )} )
+                    values ( {string.Join( ", ", values )} );";
+            }
+
+            /// <summary>
+            /// Builds the SQL statement to update a record with the given column mappings.
+            /// </summary>
+            /// <param name="table">Table in which to update the record.</param>
+            /// <param name="updateMap">Updatable columns, parameter names, and current values.</param>
+            /// <param name="keyMap">Key columns, parameter names, and current values for building conditional statements.</param>
+            /// <returns>The statement to update an existing database record.</returns>
+            /// <remarks>The default implementation is for Microsoft SQL Server.</remarks>
+
+            public virtual string BuildUpdateSql( string table, IEnumerable<ColumnValue> updateMap, IEnumerable<ColumnValue> keyMap )
+            {
+                var updates = new List<string>();
+                var conditions = new List<string>();
+
+                foreach ( var (column, parameter, value) in keyMap )
+                {
+                    conditions.Add( $"{Quotename( column )} {(value == null ? "is null" : $"= @{parameter}")}" );
+                }
+
+                foreach ( var (column, parameter, value) in updateMap )
+                {
+                    updates.Add( $"{Quotename( column )} = @{parameter}" );
+                }
+
+                return $@"
+                    update {table}
+                    set {string.Join( ", ", updates )}
+                    where {string.Join( " and ", conditions )};";
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.Mapping.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Mapping.cs
@@ -3,6 +3,8 @@
 // Licensed under the Apache License, Version 2.0
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
 
+#pragma warning disable CS1591
+
 namespace Shipwright.Dataflows.Transformations
 {
     public partial record DbUpsert
@@ -11,51 +13,6 @@ namespace Shipwright.Dataflows.Transformations
         /// Declares a mapping between a record field and a database column.
         /// </summary>
 
-        public record Mapping
-        {
-            /// <summary>
-            /// Name of the record field mapped to the database column.
-            /// </summary>
-
-            public string Field { get; }
-
-            /// <summary>
-            /// Name of the database column.
-            /// </summary>
-
-            public string Column { get; }
-
-            /// <summary>
-            /// The <see cref="ColumnType"/> of the mapping.
-            /// </summary>
-
-            public ColumnType Type { get; }
-
-
-            /// <summary>
-            /// Maps a record field to a database column.
-            /// </summary>
-            /// <param name="field">Name of the record field mapped to the database column.</param>
-            /// <param name="column">Name of the database column.</param>
-            /// <param name="type">The <see cref="ColumnType"/> of the mapping.</param>
-
-            public Mapping( string field, string column, ColumnType type )
-            {
-                Field = field;
-                Column = column;
-                Type = type;
-            }
-
-            /// <summary>
-            /// Type deconstructor.
-            /// </summary>
-
-            public void Deconstruct( out string field, out string column, out ColumnType type )
-            {
-                field = Field;
-                column = Column;
-                type = Type;
-            }
-        }
+        public record Mapping( string Field, string Column, ColumnType Type );
     }
 }

--- a/src/Dataflows/Transformations/DbUpsert.Mapping.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Mapping.cs
@@ -1,0 +1,61 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Declares a mapping between a record field and a database column.
+        /// </summary>
+
+        public record Mapping
+        {
+            /// <summary>
+            /// Name of the record field mapped to the database column.
+            /// </summary>
+
+            public string Field { get; }
+
+            /// <summary>
+            /// Name of the database column.
+            /// </summary>
+
+            public string Column { get; }
+
+            /// <summary>
+            /// The <see cref="ColumnType"/> of the mapping.
+            /// </summary>
+
+            public ColumnType Type { get; }
+
+
+            /// <summary>
+            /// Maps a record field to a database column.
+            /// </summary>
+            /// <param name="field">Name of the record field mapped to the database column.</param>
+            /// <param name="column">Name of the database column.</param>
+            /// <param name="type">The <see cref="ColumnType"/> of the mapping.</param>
+
+            public Mapping( string field, string column, ColumnType type )
+            {
+                Field = field;
+                Column = column;
+                Type = type;
+            }
+
+            /// <summary>
+            /// Type deconstructor.
+            /// </summary>
+
+            public void Deconstruct( out string field, out string column, out ColumnType type )
+            {
+                field = Field;
+                column = Column;
+                type = Type;
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.Validator.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Validator.cs
@@ -25,12 +25,15 @@ namespace Shipwright.Dataflows.Transformations
             {
                 bool HaveDefinedFieldNames( DbUpsert transformation, IEnumerable<Mapping> mappings, PropertyValidatorContext context )
                 {
-                    foreach ( var (field, column, type) in mappings )
+                    if ( mappings != null )
                     {
-                        if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( column ) )
+                        foreach ( var (field, column, type) in mappings )
                         {
-                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.DbUpsertMissingElementName );
-                            return false;
+                            if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( column ) )
+                            {
+                                context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.DbUpsertMissingElementName );
+                                return false;
+                            }
                         }
                     }
 
@@ -39,11 +42,14 @@ namespace Shipwright.Dataflows.Transformations
 
                 bool HaveAtLeastOneKey( DbUpsert transformation, IEnumerable<Mapping> mappings, PropertyValidatorContext context )
                 {
-                    foreach ( var (field, column, type) in mappings )
+                    if ( mappings != null )
                     {
-                        if ( type == ColumnType.Key )
+                        foreach ( var (field, column, type) in mappings )
                         {
-                            return true;
+                            if ( type == ColumnType.Key )
+                            {
+                                return true;
+                            }
                         }
                     }
 
@@ -54,6 +60,8 @@ namespace Shipwright.Dataflows.Transformations
                 RuleFor( _ => _.ConnectionInfo ).NotNull();
                 RuleFor( _ => _.Mappings ).NotNull().NotEmpty().Must( HaveDefinedFieldNames ).Must( HaveAtLeastOneKey );
                 RuleFor( _ => _.Table ).NotNull().NotWhiteSpace();
+                RuleFor( _ => _.SqlHelper ).NotNull();
+                RuleFor( _ => _.DuplicateKeyEventMessage ).NotNull();
             }
         }
     }

--- a/src/Dataflows/Transformations/DbUpsert.Validator.cs
+++ b/src/Dataflows/Transformations/DbUpsert.Validator.cs
@@ -1,0 +1,60 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using FluentValidation.Validators;
+using System.Collections.Generic;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record DbUpsert
+    {
+        /// <summary>
+        /// Validator for <see cref="DbUpsert"/> transformations.
+        /// </summary>
+
+        public class Validator : AbstractValidator<DbUpsert>
+        {
+            /// <summary>
+            /// Validator for <see cref="DbUpsert"/> transformations.
+            /// </summary>
+
+            public Validator()
+            {
+                bool HaveDefinedFieldNames( DbUpsert transformation, IEnumerable<Mapping> mappings, PropertyValidatorContext context )
+                {
+                    foreach ( var (field, column, type) in mappings )
+                    {
+                        if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( column ) )
+                        {
+                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.DbUpsertMissingElementName );
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                bool HaveAtLeastOneKey( DbUpsert transformation, IEnumerable<Mapping> mappings, PropertyValidatorContext context )
+                {
+                    foreach ( var (field, column, type) in mappings )
+                    {
+                        if ( type == ColumnType.Key )
+                        {
+                            return true;
+                        }
+                    }
+
+                    context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.DbUpsertMissingKey );
+                    return false;
+                }
+
+                RuleFor( _ => _.ConnectionInfo ).NotNull();
+                RuleFor( _ => _.Mappings ).NotNull().NotEmpty().Must( HaveDefinedFieldNames ).Must( HaveAtLeastOneKey );
+                RuleFor( _ => _.Table ).NotNull().NotWhiteSpace();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/DbUpsert.cs
+++ b/src/Dataflows/Transformations/DbUpsert.cs
@@ -1,0 +1,56 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Databases;
+using System.Collections.Generic;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    /// <summary>
+    /// Transformation that inserts/updates database record based on current record values.
+    /// </summary>
+
+    public partial record DbUpsert : Transformation
+    {
+        /// <summary>
+        /// Database connection information.
+        /// </summary>
+
+        public DbConnectionInfo ConnectionInfo { get; init; } = null!;
+
+        /// <summary>
+        /// Database table to which to write.
+        /// </summary>
+
+        public string Table { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Helper for building DBMS-specific SQL statements.
+        /// </summary>
+
+        public Helper SqlHelper { get; init; } = null!;
+
+        /// <summary>
+        /// Collection of database field mappings.
+        /// </summary>
+
+        public ICollection<Mapping> Mappings { get; init; } = new List<Mapping>();
+
+        /// <summary>
+        /// Defines a delegate for generating an event message for when duplicate keys are detected.
+        /// </summary>
+        /// <param name="count">Number of matching records.</param>
+        /// <returns>A formatted event message.</returns>
+
+        public delegate string DuplicateKeyEventDelegate( int count );
+
+        /// <summary>
+        /// Delegate for generating an event message when the configured database key is not unique.
+        /// </summary>
+
+        public DuplicateKeyEventDelegate DuplicateKeyEventMessage { get; init; } = count =>
+            string.Format( Resources.CoreErrorMessages.DbUpsertKeyNotUnique, count );
+    }
+}

--- a/src/Dataflows/Transformations/DefaultValue.Handler.cs
+++ b/src/Dataflows/Transformations/DefaultValue.Handler.cs
@@ -47,7 +47,7 @@ namespace Shipwright.Dataflows.Transformations
 
                     if ( missing )
                     {
-                        record.Data[field] = @default;
+                        record.Data[field] = @default();
                     }
                 }
             }

--- a/src/Dataflows/Transformations/DefaultValue.cs
+++ b/src/Dataflows/Transformations/DefaultValue.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
 
+using System;
 using System.Collections.Generic;
 
 namespace Shipwright.Dataflows.Transformations
@@ -18,7 +19,7 @@ namespace Shipwright.Dataflows.Transformations
         /// Collection of default values mapped to their field names.
         /// </summary>
 
-        public ICollection<(string field, object value)> Defaults { get; init; } = new List<(string, object)>();
+        public ICollection<(string field, Func<object> factory)> Defaults { get; init; } = new List<(string, Func<object>)>();
 
         /// <summary>
         /// Whether to overwrite blank/whitespace text values with the default value.

--- a/src/Resources/CoreErrorMessages.Designer.cs
+++ b/src/Resources/CoreErrorMessages.Designer.cs
@@ -61,11 +61,38 @@ namespace Shipwright.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Database query lookup failed. The query returned {0} matching records..
+        ///   Looks up a localized string similar to Database query lookup failed; the query returned {0} matching records.
         /// </summary>
         public static string DbLookupFailureMessage {
             get {
                 return ResourceManager.GetString("DbLookupFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Database upsert failed; the key parameter values are not unique.
+        /// </summary>
+        public static string DbUpsertKeyNotUnique {
+            get {
+                return ResourceManager.GetString("DbUpsertKeyNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; field and column names cannot be null, empty, nor whitespace.
+        /// </summary>
+        public static string DbUpsertMissingElementName {
+            get {
+                return ResourceManager.GetString("DbUpsertMissingElementName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must have at least one Key column mapping.
+        /// </summary>
+        public static string DbUpsertMissingKey {
+            get {
+                return ResourceManager.GetString("DbUpsertMissingKey", resourceCulture);
             }
         }
         

--- a/src/Resources/CoreErrorMessages.resx
+++ b/src/Resources/CoreErrorMessages.resx
@@ -118,7 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DbLookupFailureMessage" xml:space="preserve">
-    <value>Database query lookup failed. The query returned {0} matching records.</value>
+    <value>Database query lookup failed; the query returned {0} matching records</value>
+  </data>
+  <data name="DbUpsertKeyNotUnique" xml:space="preserve">
+    <value>Database upsert failed; the key parameter values are not unique</value>
+  </data>
+  <data name="DbUpsertMissingElementName" xml:space="preserve">
+    <value>'{PropertyName}' field and column names cannot be null, empty, nor whitespace</value>
+  </data>
+  <data name="DbUpsertMissingKey" xml:space="preserve">
+    <value>'{PropertyName}' must have at least one Key column mapping</value>
   </data>
   <data name="MissingRequiredFieldValue" xml:space="preserve">
     <value>Required value is missing from the field [{0}]</value>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.3</Version>
+    <Version>1.0.0-preview.4</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4</Version>
+    <Version>1.0.0-preview.4.1</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/test/Cases.cs
+++ b/test/Cases.cs
@@ -3,7 +3,10 @@
 // Licensed under the Apache License, Version 2.0
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
 
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Shipwright
 {
@@ -55,6 +58,23 @@ namespace Shipwright
         }
 
         /// <summary>
+        /// Attribute for injecting null and whitespace cases.
+        /// </summary>
+
+        public class NullAndWhiteSpaceAttribute : DataAttribute
+        {
+            public override IEnumerable<object[]> GetData( MethodInfo testMethod )
+            {
+                var values = new[] { string.Empty, WhiteSpace, null };
+
+                foreach ( var value in values )
+                {
+                    yield return new[] { value };
+                }
+            }
+        }
+
+        /// <summary>
         /// Collection of boolean cases.
         /// </summary>
 
@@ -64,6 +84,15 @@ namespace Shipwright
             {
                 Add( true );
                 Add( false );
+            }
+        }
+
+        public class BooleanCasesAttribute : DataAttribute
+        {
+            public override IEnumerable<object[]> GetData( MethodInfo testMethod )
+            {
+                yield return new object[] { true };
+                yield return new object[] { false };
             }
         }
     }

--- a/test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
+++ b/test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
@@ -1,0 +1,66 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using Shipwright.Databases;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbUpsert;
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests
+{
+    public class FactoryTests
+    {
+        private IDbConnectionDispatcher connectionDispatcher;
+        private ITransformationFactory<DbUpsert> instance() => new Factory( connectionDispatcher );
+
+        private readonly Mock<IDbConnectionDispatcher> mockConnectionDispatcher;
+
+        public FactoryTests()
+        {
+            mockConnectionDispatcher = Mockery.Of( out connectionDispatcher );
+        }
+
+        public class Constructor : FactoryTests
+        {
+            [Fact]
+            public void requires_connectionDispatcher()
+            {
+                connectionDispatcher = null!;
+                Assert.Throws<ArgumentNullException>( nameof( connectionDispatcher ), instance );
+            }
+        }
+
+        public class Create : FactoryTests
+        {
+            private DbUpsert transformation = new DbUpsert { ConnectionInfo = new FakeConnectionInfo() };
+            private CancellationToken cancellationToken;
+            private Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
+
+            [Fact]
+            public async Task requires_transformation()
+            {
+                transformation = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );
+            }
+
+            [Theory, Cases.BooleanCases]
+            public async Task returns_configured_handler( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var connectionFactory = Mockery.Of<IDbConnectionFactory>();
+                mockConnectionDispatcher.Setup( _ => _.Build( transformation.ConnectionInfo, cancellationToken ) ).ReturnsAsync( connectionFactory );
+
+                var actual = await method();
+                var typed = Assert.IsType<Handler>( actual );
+                Assert.Same( transformation, typed.transformation );
+                Assert.Same( connectionFactory, typed.connectionFactory );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbUpsertTests/FakeSqlHelper.cs
+++ b/test/Dataflows/Transformations/DbUpsertTests/FakeSqlHelper.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests
+{
+    /// <summary>
+    /// Fake SQL helper.
+    /// </summary>
+
+    public class FakeSqlHelper : DbUpsert.Helper { }
+}

--- a/test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
@@ -1,0 +1,334 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbUpsert;
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests
+{
+    public class HandlerTests
+    {
+        private DbUpsert transformation = new DbUpsert { ConnectionInfo = new FakeConnectionInfo(), SqlHelper = new FakeSqlHelper() };
+        private IDbConnectionFactory connectionFactory;
+
+        private ITransformationHandler instance() => new Handler( transformation, connectionFactory );
+
+        private readonly Mock<IDbConnectionFactory> mockConnectionFactory;
+        private readonly Fixture fixture = new Fixture();
+
+        public HandlerTests()
+        {
+            mockConnectionFactory = Mockery.Of( out connectionFactory );
+        }
+
+        public class Constructor : HandlerTests
+        {
+            [Fact]
+            public void requires_transformation()
+            {
+                transformation = null!;
+                Assert.Throws<ArgumentNullException>( nameof( transformation ), instance );
+            }
+
+            [Fact]
+            public void requires_connectionFactory()
+            {
+                connectionFactory = null!;
+                Assert.Throws<ArgumentNullException>( nameof( connectionFactory ), instance );
+            }
+        }
+
+        public class ShouldUpdate : HandlerTests
+        {
+            private readonly Record record = FakeRecord.Create();
+            private readonly IDictionary<string, object> current = new Dictionary<string, object>();
+            private string sql;
+            private IDictionary<string, object> parameters;
+
+            private new Handler instance() => base.instance() as Handler;
+            private bool method() => instance().ShouldUpdate( record, current, out sql, out parameters );
+
+            [Fact]
+            public async Task returns_false_when_upsert_values_identical()
+            {
+                var mappings = new List<Mapping>
+                {
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Insert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Trigger },
+                };
+
+                foreach ( var (field, parameter, type) in mappings )
+                {
+                    record.Data[field] = current[parameter] = fixture.Create<string>();
+                }
+
+                var keyMap = new List<ColumnValue>
+                {
+                    new ColumnValue( mappings[0].Column, "p1", record.Data[mappings[0].Field] ),
+                    new ColumnValue( mappings[1].Column, "p2", record.Data[mappings[1].Field]  ),
+                };
+
+                var updateMap = new List<ColumnValue>
+                {
+                    // trigger column should be included in any update, regardless of whether it has changed
+                    new ColumnValue( mappings[5].Column, "p5", record.Data[mappings[5].Field] ),
+                };
+
+                var expectedSql = transformation.SqlHelper.BuildUpdateSql( transformation.Table, updateMap, keyMap );
+                var expectedParameters = keyMap.Union( updateMap ).ToDictionary( _ => _.Parameter, _ => _.Value );
+
+                transformation = transformation with { Mappings = mappings };
+                var actual = method();
+
+                Assert.False( actual );
+                Assert.Equal( expectedSql, sql );
+                Assert.Equal( expectedParameters, parameters );
+            }
+
+            [Fact]
+            public async Task returns_true_when_basic_upsert_values_different()
+            {
+                var mappings = new List<Mapping>
+                {
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Insert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Trigger },
+                };
+
+                foreach ( var (field, parameter, type) in mappings )
+                {
+                    record.Data[field] = current[parameter] = fixture.Create<string>();
+                }
+
+                var keyMap = new List<ColumnValue>
+                {
+                    new ColumnValue( mappings[0].Column, "p1", record.Data[mappings[0].Field] ),
+                    new ColumnValue( mappings[1].Column, "p2", record.Data[mappings[1].Field]  ),
+                };
+
+                var updateMap = new List<ColumnValue>
+                {
+                    // only the changed columns should be included in an update
+                    new ColumnValue( mappings[3].Column, "p3", record.Data[mappings[3].Field] = fixture.Create<string>() ),
+                    new ColumnValue( mappings[4].Column, "p4", record.Data[mappings[4].Field] = fixture.Create<string>() ),
+
+                    // trigger column should be included in any update, regardless of whether it has changed
+                    new ColumnValue( mappings[6].Column, "p6", record.Data[mappings[6].Field] ),
+                };
+
+                var expectedSql = transformation.SqlHelper.BuildUpdateSql( transformation.Table, updateMap, keyMap );
+                var expectedParameters = keyMap.Union( updateMap ).ToDictionary( _ => _.Parameter, _ => _.Value );
+
+                transformation = transformation with { Mappings = mappings };
+                var actual = method();
+
+                Assert.True( actual );
+                Assert.Equal( expectedSql, sql );
+                Assert.Equal( expectedParameters, parameters );
+            }
+
+            [Fact]
+            public async Task returns_true_when_structural_upsert_values_different()
+            {
+                var mappings = new List<Mapping>
+                {
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Key },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Insert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Upsert },
+                    fixture.Create<Mapping>() with { Type = ColumnType.Trigger },
+                };
+
+                foreach ( var (field, parameter, type) in mappings )
+                {
+                    record.Data[field] = current[parameter] = fixture.Create<string>();
+                }
+
+                var keyMap = new List<ColumnValue>
+                {
+                    new ColumnValue( mappings[0].Column, "p1", record.Data[mappings[0].Field] ),
+                    new ColumnValue( mappings[1].Column, "p2", record.Data[mappings[1].Field]  ),
+                };
+
+                var updateMap = new List<ColumnValue>
+                {
+                    // only the changed columns should be included in an update
+                    new ColumnValue( mappings[3].Column, "p3", record.Data[mappings[3].Field] = fixture.CreateMany<int>() ),
+                    new ColumnValue( mappings[4].Column, "p4", record.Data[mappings[4].Field] = fixture.CreateMany<int>() ),
+
+                    // trigger column should be included in any update, regardless of whether it has changed
+                    new ColumnValue( mappings[6].Column, "p6", record.Data[mappings[6].Field] ),
+                };
+
+                current[mappings[3].Column] = fixture.CreateMany<int>();
+                current[mappings[4].Column] = fixture.CreateMany<int>();
+
+                var expectedSql = transformation.SqlHelper.BuildUpdateSql( transformation.Table, updateMap, keyMap );
+                var expectedParameters = keyMap.Union( updateMap ).ToDictionary( _ => _.Parameter, _ => _.Value );
+
+                transformation = transformation with { Mappings = mappings };
+                var actual = method();
+
+                Assert.True( actual );
+                Assert.Equal( expectedSql, sql );
+                Assert.Equal( expectedParameters, parameters );
+            }
+        }
+
+        public class Transform : HandlerTests
+        {
+            private new Handler instance() => mockHandler.Object;
+
+            private readonly Mock<Handler> mockHandler;
+
+            private Record record = FakeRecord.Create();
+            private CancellationToken cancellationToken;
+            private Task method() => instance().Transform( record, cancellationToken );
+
+            public Transform()
+            {
+                mockHandler = new Mock<Handler>( MockBehavior.Loose, transformation, connectionFactory ) { CallBase = true };
+                transformation = new DbUpsert
+                {
+                    ConnectionInfo = new FakeConnectionInfo(),
+                    Table = fixture.Create<string>(),
+                    SqlHelper = new FakeSqlHelper(),
+                    DuplicateKeyEventMessage = count => string.Format( Resources.CoreErrorMessages.DbUpsertKeyNotUnique, count ),
+                    Mappings = Enum.GetValues<ColumnType>().Select( type => fixture.Create<Mapping>() with { Type = type } ).ToList(),
+                };
+            }
+
+            [Fact]
+            public async Task requires_record()
+            {
+                record = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
+            }
+
+            [Fact]
+            public async Task when_canceled_fails_to_obtain_semaphore()
+            {
+                cancellationToken = new CancellationToken( true );
+
+                var keys = fixture.Create<IDictionary<string, object>>();
+                var select = fixture.Create<string>();
+                mockHandler.Setup( _ => _.BuildSelectSql( record, out keys ) ).Returns( select ).Verifiable();
+
+                await Assert.ThrowsAsync<TaskCanceledException>( method );
+
+                mockHandler.Verify( _ => _.BuildSelectSql( record, out keys ), Times.Once() );
+                mockHandler.Verify( _ => _.Lock( keys, cancellationToken ), Times.Once() );
+            }
+
+            [Fact]
+            public async Task when_query_returns_multiple_records_adds_event()
+            {
+                var keys = fixture.Create<IDictionary<string, object>>();
+                var select = fixture.Create<string>();
+                mockHandler.Setup( _ => _.BuildSelectSql( record, out keys ) ).Returns( select ).Verifiable();
+
+                var matches = fixture.CreateMany<IDictionary<string, object>>();
+                mockHandler.Setup( _ => _.Query( select, keys, cancellationToken ) ).ReturnsAsync( matches ).Verifiable();
+
+                var expectedData = new Dictionary<string, object>( record.Data );
+                var expectedEvents = new List<LogEvent> { new LogEvent
+                {
+                    IsFatal = true,
+                    Level = LogLevel.Error,
+                    Description = transformation.DuplicateKeyEventMessage( matches.Count() ),
+                    Value = new { sql = select, keys }
+                }};
+
+                await method();
+                Assert.Equal( expectedData, record.Data );
+                Assert.Equal( JsonSerializer.Serialize( expectedEvents ), JsonSerializer.Serialize( record.Events ) );
+            }
+
+            [Fact]
+            public async Task when_query_returns_no_records_performs_insert()
+            {
+                var keys = fixture.Create<IDictionary<string, object>>();
+                var select = fixture.Create<string>();
+                mockHandler.Setup( _ => _.BuildSelectSql( record, out keys ) ).Returns( select ).Verifiable();
+                mockHandler.Setup( _ => _.Query( select, keys, cancellationToken ) ).ReturnsAsync( Array.Empty<IDictionary<string, object>>() ).Verifiable();
+
+                var insert = fixture.Create<string>();
+                var parameters = fixture.Create<IDictionary<string, object>>();
+                mockHandler.Setup( _ => _.BuildInsertSql( record, out parameters ) ).Returns( insert );
+                mockHandler.Setup( _ => _.Execute( insert, parameters, cancellationToken ) ).Returns( Task.CompletedTask ).Verifiable();
+
+                var expectedData = new Dictionary<string, object>( record.Data );
+
+                await method();
+                Assert.Equal( expectedData, record.Data );
+                Assert.Empty( record.Events );
+
+                mockHandler.Verify();
+                mockHandler.Verify( _ => _.Execute( insert, parameters, cancellationToken ), Times.Once() );
+            }
+
+            [Fact]
+            public async Task when_query_returns_single_record_without_change_no_op()
+            {
+                var keys = fixture.Create<IDictionary<string, object>>();
+                var select = fixture.Create<string>();
+                mockHandler.Setup( _ => _.BuildSelectSql( record, out keys ) ).Returns( select ).Verifiable();
+
+                var matches = fixture.CreateMany<IDictionary<string, object>>( 1 );
+                mockHandler.Setup( _ => _.Query( select, keys, cancellationToken ) ).ReturnsAsync( matches ).Verifiable();
+
+                var current = matches.Single();
+                var update = fixture.Create<string>();
+                var parameters = fixture.Create<IDictionary<string, object>>();
+                mockHandler.Setup( _ => _.ShouldUpdate( record, current, out update, out parameters ) ).Returns( false );
+
+                await method();
+                mockHandler.Verify();
+                mockHandler.Verify( _ => _.Execute( update, parameters, cancellationToken ), Times.Never() );
+            }
+
+            [Fact]
+            public async Task when_query_returns_single_record_with_changes_updates()
+            {
+                var keys = fixture.Create<IDictionary<string, object>>();
+                var select = fixture.Create<string>();
+                mockHandler.Setup( _ => _.BuildSelectSql( record, out keys ) ).Returns( select ).Verifiable();
+
+                var matches = fixture.CreateMany<IDictionary<string, object>>( 1 );
+                mockHandler.Setup( _ => _.Query( select, keys, cancellationToken ) ).ReturnsAsync( matches ).Verifiable();
+
+                var current = matches.Single();
+                var update = fixture.Create<string>();
+                var parameters = fixture.Create<IDictionary<string, object>>();
+                mockHandler.Setup( _ => _.ShouldUpdate( record, current, out update, out parameters ) ).Returns( true );
+                mockHandler.Setup( _ => _.Execute( update, parameters, cancellationToken ) ).Returns( Task.CompletedTask ).Verifiable();
+
+                await method();
+                mockHandler.Verify();
+                mockHandler.Verify( _ => _.Execute( update, parameters, cancellationToken ), Times.Once() );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -1,0 +1,95 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using AutoFixture.Xunit2;
+using FluentValidation;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.DbUpsert;
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests
+{
+    public class ValidatorTests
+    {
+        private readonly IValidator<DbUpsert> validator = new Validator();
+
+        public class ConnectionInfo : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.ConnectionInfo, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.ConnectionInfo, new FakeConnectionInfo() );
+        }
+
+        public class Table : ValidatorTests
+        {
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_null_or_whitespace( string value ) => validator.InvalidWhen( _ => _.Table, value );
+
+            [Theory, AutoData]
+            public void valid_when_given( string value ) => validator.ValidWhen( _ => _.Table, value );
+        }
+
+        public class SqlHelper : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.SqlHelper, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.SqlHelper, new FakeSqlHelper() );
+        }
+
+        public class Mappings : ValidatorTests
+        {
+            private readonly Fixture fixture = new Fixture();
+            private readonly List<Mapping> valid = new List<Mapping>();
+
+            public Mappings()
+            {
+                foreach ( var type in Enum.GetValues<ColumnType>() )
+                {
+                    valid.Add( fixture.Create<Mapping>() with { Type = type } );
+                }
+            }
+
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Mappings, null );
+
+            [Fact]
+            public void invalid_when_empty() => validator.InvalidWhen( _ => _.Mappings, new List<Mapping>() );
+
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_any_field_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Mappings, new List<Mapping>( valid ) { fixture.Create<Mapping>() with { Field = value } } );
+
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_any_column_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Mappings, new List<Mapping>( valid ) { fixture.Create<Mapping>() with { Column = value } } );
+
+            [Fact]
+            public void invalid_when_no_keys() => validator.InvalidWhen( _ => _.Mappings, valid.Where( _ => _.Type != ColumnType.Key ).ToList() );
+
+            [Fact]
+            public void valid_when_one_key() => validator.ValidWhen( _ => _.Mappings, valid );
+
+            [Fact]
+            public void valid_when_multiple_keys() => validator.ValidWhen( _ => _.Mappings, new List<Mapping>( valid ) { fixture.Create<Mapping>() with { Type = ColumnType.Key } } );
+        }
+
+        public class DuplicateKeyEventMessage : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.DuplicateKeyEventMessage, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.DuplicateKeyEventMessage, count => $"{count}" );
+        }
+    }
+}

--- a/test/Dataflows/Transformations/DefaultValueTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/DefaultValueTests/HandlerTests.cs
@@ -47,18 +47,19 @@ namespace Shipwright.Dataflows.Transformations.DefaultValueTests
             public async Task defaults_value_when_missing( bool defaultOnBlank )
             {
                 var fixture = FakeRecord.Fixture();
+                var prefix = Guid.NewGuid();
 
                 transformation = new DefaultValue
                 {
                     DefaultOnBlank = defaultOnBlank,
-                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, (object)Guid.NewGuid()) ).ToList(),
+                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, new Func<object>( () => $"{prefix}{field}" )) ).ToList()
                 };
 
                 var expected = new Dictionary<string, object>( record.Data );
 
                 foreach ( var (field, value) in transformation.Defaults )
                 {
-                    expected[field] = value;
+                    expected[field] = value();
                     record.Data.Remove( field );
                 }
 
@@ -70,18 +71,19 @@ namespace Shipwright.Dataflows.Transformations.DefaultValueTests
             public async Task defaults_value_when_null( bool defaultOnBlank )
             {
                 var fixture = FakeRecord.Fixture();
+                var prefix = Guid.NewGuid();
 
                 transformation = new DefaultValue
                 {
                     DefaultOnBlank = defaultOnBlank,
-                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, (object)Guid.NewGuid()) ).ToList(),
+                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, new Func<object>( () => $"{prefix}{field}" )) ).ToList()
                 };
 
                 var expected = new Dictionary<string, object>( record.Data );
 
                 foreach ( var (field, value) in transformation.Defaults )
                 {
-                    expected[field] = value;
+                    expected[field] = value();
                     record.Data[field] = null;
                 }
 
@@ -93,11 +95,12 @@ namespace Shipwright.Dataflows.Transformations.DefaultValueTests
             public async Task retains_whitespace_when_not_defaulting_on_blank( string whitespace )
             {
                 var fixture = FakeRecord.Fixture();
+                var prefix = Guid.NewGuid();
 
                 transformation = new DefaultValue
                 {
                     DefaultOnBlank = false,
-                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, (object)Guid.NewGuid()) ).ToList(),
+                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, new Func<object>( () => $"{prefix}{field}" )) ).ToList()
                 };
 
                 foreach ( var (field, value) in transformation.Defaults )
@@ -116,18 +119,19 @@ namespace Shipwright.Dataflows.Transformations.DefaultValueTests
             public async Task replaces_whitespace_when_defaulting_on_blank( string whitespace )
             {
                 var fixture = FakeRecord.Fixture();
+                var prefix = Guid.NewGuid();
 
                 transformation = new DefaultValue
                 {
                     DefaultOnBlank = true,
-                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, (object)Guid.NewGuid()) ).ToList(),
+                    Defaults = fixture.CreateMany<string>( 3 ).Select( field => (field, new Func<object>( () => $"{prefix}{field}" )) ).ToList()
                 };
 
                 var expected = new Dictionary<string, object>( record.Data );
 
                 foreach ( var (field, value) in transformation.Defaults )
                 {
-                    expected[field] = value;
+                    expected[field] = value();
                     record.Data[field] = whitespace;
                 }
 

--- a/test/Dataflows/Transformations/DefaultValueTests/ValidatorTests.cs
+++ b/test/Dataflows/Transformations/DefaultValueTests/ValidatorTests.cs
@@ -4,6 +4,7 @@
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
 
 using FluentValidation;
+using System;
 using System.Collections.Generic;
 using Xunit;
 using static Shipwright.Dataflows.Transformations.DefaultValue;
@@ -20,7 +21,7 @@ namespace Shipwright.Dataflows.Transformations.DefaultValueTests
             public void invalid_when_null() => validator.InvalidWhen( _ => _.Defaults, null );
 
             [Fact]
-            public void valid_when_given() => validator.ValidWhen( _ => _.Defaults, new List<(string, object)>() );
+            public void valid_when_given() => validator.ValidWhen( _ => _.Defaults, new List<(string, Func<object>)>() );
         }
     }
 }


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1468
---
### Problem
As an ETL developer, I want to perform a database upsert (insert/update) using values from a dataflow record so that values in a dataflow can be written to a target database.

### Solution
- Added DbUpsert transformation that allows the developer to specify:
- Table
- A helper for generating the correct flavor of SQL.
- Key fields used to isolate the record to update.
- Insert-only fields for filling in fields that are only touched at insert-time.
- Upsert fields, which are either inserted if the record is new or updated if the field value has changed.
- Trigger fields that are updated when any other field has changed (useful for timestamps that record when a record was last updated.
- Change detection for producing the smallest update possible (for those databases that can take advantage of such a thing).

### Additional Notes
- Unlike previous generations, I removed output column mapping. The same functionality can be gained with the DbLookup transformation if it is desired.
- The DefaultValue transformation was changed to a value factory so that non-deterministic values (like timestamps) could be added closer to when operations like a DbUpsert would be performed.