### PR TITLE
NET-1369: Delegate code transformation

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4.5</Version>
+    <Version>1.0.0-preview.4.6</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/lamar/test/Dataflows/LamarDataflowExtensionsTests.cs
+++ b/lamar/test/Dataflows/LamarDataflowExtensionsTests.cs
@@ -93,7 +93,7 @@ namespace Shipwright.Dataflows
                 // outer decorator should be event inspection
                 var inspection = Assert.IsType<Transformations.Internal.EventInspectionFactoryDecorator<FakeTransformation>>( instance );
 
-                // next decorator should be cancellation
+                // next decorator should be throttling
                 var throttling = Assert.IsType<Transformations.Internal.ThrottleableFactoryDecorator<FakeTransformation>>( inspection.inner );
 
                 // next decorator should be cancellation

--- a/src/Dataflows/Transformations/Code.Factory.cs
+++ b/src/Dataflows/Transformations/Code.Factory.cs
@@ -1,0 +1,32 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record Code
+    {
+        /// <summary>
+        /// Factory for the <see cref="Code"/> transformation.
+        /// </summary>
+
+        public class Factory : ITransformationFactory<Code>
+        {
+            /// <summary>
+            /// Creates a handler for the given transformation.
+            /// </summary>
+
+            public async Task<ITransformationHandler> Create( Code transformation, CancellationToken cancellationToken )
+            {
+                if ( transformation == null ) throw new ArgumentNullException( nameof( transformation ) );
+
+                return new Handler( transformation );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/Code.Handler.cs
+++ b/src/Dataflows/Transformations/Code.Handler.cs
@@ -1,0 +1,43 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record Code
+    {
+        /// <summary>
+        /// Handler for the <see cref="Code"/> transformation.
+        /// </summary>
+
+        public class Handler : TransformationHandler
+        {
+            internal readonly Code transformation;
+
+            /// <summary>
+            /// Handler for the <see cref="Code"/> transformation.
+            /// </summary>
+
+            public Handler( Code transformation )
+            {
+                this.transformation = transformation ?? throw new ArgumentNullException( nameof( transformation ) );
+            }
+
+            /// <summary>
+            /// Executes the transformation delegate against the given dataflow record.
+            /// </summary>
+
+            public override async Task Transform( Record record, CancellationToken cancellationToken )
+            {
+                if ( record == null ) throw new ArgumentNullException( nameof( record ) );
+
+                await transformation.Delegate( record, cancellationToken );
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/Code.Validator.cs
+++ b/src/Dataflows/Transformations/Code.Validator.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    public partial record Code
+    {
+        /// <summary>
+        /// Validator for the <see cref="Code"/> transformation.
+        /// </summary>
+
+        public class Validator : AbstractValidator<Code>
+        {
+            /// <summary>
+            /// Validator for the <see cref="Code"/> transformation.
+            /// </summary>
+
+            public Validator()
+            {
+                RuleFor( _ => _.Delegate ).NotNull();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Transformations/Code.cs
+++ b/src/Dataflows/Transformations/Code.cs
@@ -1,0 +1,31 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shipwright.Dataflows.Transformations
+{
+    /// <summary>
+    /// Transformation that executes a delegate against a dataflow record.
+    /// </summary>
+
+    public partial record Code : Transformation
+    {
+        /// <summary>
+        /// Defines a delegate for executing code against a dataflow record.
+        /// </summary>
+        /// <param name="record">The dataflow record being transformed.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+
+        public delegate Task CodeDelegate( Record record, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Code to execute against dataflow records.
+        /// </summary>
+
+        public CodeDelegate Delegate { get; init; } = ( record, ct ) => Task.CompletedTask;
+    }
+}

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4.5</Version>
+    <Version>1.0.0-preview.4.6</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/test/Dataflows/Transformations/CodeTests/FactoryTests.cs
+++ b/test/Dataflows/Transformations/CodeTests/FactoryTests.cs
@@ -1,0 +1,43 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.Code;
+
+namespace Shipwright.Dataflows.Transformations.CodeTests
+{
+    public class FactoryTests
+    {
+        private ITransformationFactory<Code> instance() => new Factory();
+
+        public class Create : FactoryTests
+        {
+            private Code transformation = new Code();
+            private CancellationToken cancellationToken;
+
+            private Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
+
+            [Fact]
+            public async Task requires_transformation()
+            {
+                transformation = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );
+            }
+
+            [Theory, Cases.BooleanCases]
+            public async Task returns_handler( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+
+                var actual = await method();
+                var typed = Assert.IsType<Handler>( actual );
+                Assert.Same( transformation, typed.transformation );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/CodeTests/HandlerTests.cs
+++ b/test/Dataflows/Transformations/CodeTests/HandlerTests.cs
@@ -1,0 +1,56 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.Code;
+
+namespace Shipwright.Dataflows.Transformations.CodeTests
+{
+    public class HandlerTests
+    {
+        private Code transformation = new Code { };
+        private ITransformationHandler instance() => new Handler( transformation );
+
+        public class Constructor : HandlerTests
+        {
+            [Fact]
+            public void requires_transformation()
+            {
+                transformation = null!;
+                Assert.Throws<ArgumentNullException>( nameof( transformation ), instance );
+            }
+        }
+
+        public class Transform : HandlerTests
+        {
+            private Record record = FakeRecord.Create();
+            private CancellationToken cancellationToken;
+            private Task method() => instance().Transform( record, cancellationToken );
+
+            [Fact]
+            public async Task requires_record()
+            {
+                record = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
+            }
+
+            [Theory, Cases.BooleanCases]
+            public async Task executes_delegate( bool canceled )
+            {
+                cancellationToken = new CancellationToken( canceled );
+                (Record record, CancellationToken cancellationToken) actual = default;
+
+                transformation = transformation with { Delegate = async ( r, ct ) => actual = (r, ct) };
+
+                await method();
+                Assert.Same( record, actual.record );
+                Assert.Equal( cancellationToken, actual.cancellationToken );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Transformations/CodeTests/ValidatorTests.cs
+++ b/test/Dataflows/Transformations/CodeTests/ValidatorTests.cs
@@ -1,0 +1,26 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Transformations.Code;
+
+namespace Shipwright.Dataflows.Transformations.CodeTests
+{
+    public class ValidatorTests
+    {
+        private readonly IValidator<Code> validator = new Validator();
+
+        public class Delegate : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Delegate, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.Delegate, ( record, CancellationToken ) => Task.CompletedTask );
+        }
+    }
+}


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1369
---
### Problem
As an ETL developer, I want to execute a delegate as a transformation so that I do not have to build boilerplate code for one-off transformations.

### Solution
Added a transformation that can execute code expressed as a delegate.