### PR TITLE
NET-1343: Database record source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Shipwright.Core
 Core components of the Shipwright Extract-Transform-Load (ETL) toolset.
 
-This project is currently experimental and uses features from a pre-release version of .NET 5.
-
 You will need one of the following to work with the code:
-- .NET 5 SDK Release Candidate 2 (RC2)
-- Visual Studio 2019 16.8 Preview 4 (includes the above SDK)
+- .NET 5 SDK
+- Visual Studio 2019 16.8 or later (includes the above SDK)
 
 # License
 Shipwright.Core and the contents of this repository are licensed under the [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). 

--- a/example/src/Shipwright.Core.Example.csproj
+++ b/example/src/Shipwright.Core.Example.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0-rc.2.20475.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.0</Version>
+    <Version>1.0.0-rc.1.1</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4.6</Version>
+    <Version>1.0.0-rc.1.0</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/lamar/test/Shipwright.Core.Lamar.Test.csproj
+++ b/lamar/test/Shipwright.Core.Lamar.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200921-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Dataflows/Sources/DbSource.Handler.cs
+++ b/src/Dataflows/Sources/DbSource.Handler.cs
@@ -1,0 +1,112 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Dapper;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Shipwright.Dataflows.Sources
+{
+    public partial record DbSource
+    {
+        /// <summary>
+        /// Handler for the <see cref="DbSource"/> data source.
+        /// </summary>
+
+        public class Handler : ISourceHandler<DbSource>
+        {
+            internal readonly IDbConnectionDispatcher connectionDispatcher;
+
+            /// <summary>
+            /// Handler for the <see cref="DbSource"/> data source.
+            /// </summary>
+
+            public Handler( IDbConnectionDispatcher connectionDispatcher )
+            {
+                this.connectionDispatcher = connectionDispatcher ?? throw new ArgumentNullException( nameof( connectionDispatcher ) );
+            }
+
+            /// <summary>
+            /// Reads a stream of records from the data source.
+            /// </summary>
+
+            public async IAsyncEnumerable<Record> Read( DbSource source, Dataflow dataflow, [EnumeratorCancellation] CancellationToken cancellationToken )
+            {
+                if ( source == null ) throw new ArgumentNullException( nameof( source ) );
+                if ( dataflow == null ) throw new ArgumentNullException( nameof( dataflow ) );
+
+                var position = 0;
+                var command = new CommandDefinition( source.Sql, parameters: source.Parameters, cancellationToken: cancellationToken );
+                var connectionFactory = await connectionDispatcher.Build( source.ConnectionInfo, cancellationToken );
+
+                using var connection = connectionFactory.Create();
+                using var reader = await connection.ExecuteReaderAsync( command );
+                var columns = new Dictionary<string, int>();
+
+                Record extract( IDataReader reader )
+                {
+                    // set ordinal field mappings on first record
+                    if ( position == 0 )
+                    {
+                        for ( var i = 0; i < reader.FieldCount; i++ )
+                        {
+                            columns[reader.GetName( i )] = i;
+                        }
+
+                        // check for any missing columns
+                        var missing = source.Output.Where( _ => !columns.ContainsKey( _.column ) ).ToList();
+
+                        // add a warning for each missing column
+                        foreach ( var (field, column) in missing )
+                        {
+                            dataflow.Events.Add( new LogEvent
+                            {
+                                IsFatal = false,
+                                Level = Microsoft.Extensions.Logging.LogLevel.Warning,
+                                Description = Resources.CoreErrorMessages.DbSourceColumnMissing,
+                                Value = new { field, column },
+                            } );
+                        }
+                    }
+
+                    var data = new Dictionary<string, object>( dataflow.FieldNameComparer );
+
+                    foreach ( var (field, column) in source.Output )
+                    {
+                        if ( columns.TryGetValue( column, out var ordinal ) )
+                        {
+                            data[field] = reader.IsDBNull( ordinal ) ? null! : reader.GetValue( ordinal );
+                        }
+                    }
+
+                    return new Record( dataflow, source, data, ++position );
+                }
+
+                // read asynchronously when supported
+                if ( reader is DbDataReader asyncReader )
+                {
+                    while ( await asyncReader.ReadAsync( cancellationToken ) )
+                    {
+                        yield return extract( asyncReader );
+                    }
+                }
+
+                else
+                {
+                    while ( reader.Read() )
+                    {
+                        yield return extract( reader );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Dataflows/Sources/DbSource.Validator.cs
+++ b/src/Dataflows/Sources/DbSource.Validator.cs
@@ -1,0 +1,56 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+using FluentValidation.Validators;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shipwright.Dataflows.Sources
+{
+    public partial record DbSource
+    {
+        /// <summary>
+        /// Validator for the <see cref="DbSource"/> data source.
+        /// </summary>
+
+        public class Validator : AbstractValidator<DbSource>
+        {
+            /// <summary>
+            /// Validator for the <see cref="DbSource"/> data source.
+            /// </summary>
+
+            public Validator()
+            {
+                // checks to see that both sides of each mapping has a value
+                bool HaveDefinedValues( DbSource source, IEnumerable<(string, string)> mappings, PropertyValidatorContext context )
+                {
+                    mappings ??= Enumerable.Empty<(string, string)>();
+
+                    foreach ( var (field, other) in mappings )
+                    {
+                        if ( field == null || other == null )
+                        {
+                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.NoNullElementsValidationMessage );
+                            return false;
+                        }
+
+                        if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( other ) )
+                        {
+                            context.MessageFormatter.AppendArgument( "ValidationMessage", Resources.CoreErrorMessages.NoWhiteSpaceElementsValidationMessage );
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                RuleFor( _ => _.ConnectionInfo ).NotNull();
+                RuleFor( _ => _.Output ).NotNull().Must( HaveDefinedValues );
+                RuleFor( _ => _.Sql ).NotNull().NotWhiteSpace();
+            }
+        }
+    }
+}

--- a/src/Dataflows/Sources/DbSource.cs
+++ b/src/Dataflows/Sources/DbSource.cs
@@ -1,0 +1,42 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Shipwright.Databases;
+using System.Collections.Generic;
+
+namespace Shipwright.Dataflows.Sources
+{
+    /// <summary>
+    /// Database query record source.
+    /// </summary>
+
+    public partial record DbSource : Source
+    {
+        /// <summary>
+        /// Connection information for the database in which to execute the source query.
+        /// </summary>
+
+        public DbConnectionInfo ConnectionInfo { get; init; } = null!;
+
+        /// <summary>
+        /// Parameterized query to use as a data source.
+        /// </summary>
+
+        public string Sql { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Anonymous object type that will be submitted as the query parameters.
+        /// </summary>
+
+        public object? Parameters { get; init; }
+
+        /// <summary>
+        /// Collection of fields that are output by the query and their query result column names.
+        /// Column names are case sensitive.
+        /// </summary>
+
+        public ICollection<(string field, string column)> Output { get; init; } = new List<(string, string)>();
+    }
+}

--- a/src/Dataflows/Transformations/Transformation.cs
+++ b/src/Dataflows/Transformations/Transformation.cs
@@ -18,6 +18,6 @@ namespace Shipwright.Dataflows.Transformations
         /// Defaults to unlimited.
         /// </summary>
 
-        public int MaxDegreeOfParallelism { get; init; } = int.MaxValue;
+        public virtual int MaxDegreeOfParallelism { get; init; } = int.MaxValue;
     }
 }

--- a/src/Resources/CoreErrorMessages.Designer.cs
+++ b/src/Resources/CoreErrorMessages.Designer.cs
@@ -70,6 +70,15 @@ namespace Shipwright.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Column name not found in database query results.
+        /// </summary>
+        public static string DbSourceColumnMissing {
+            get {
+                return ResourceManager.GetString("DbSourceColumnMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Database upsert failed; the key parameter values are not unique.
         /// </summary>
         public static string DbUpsertKeyNotUnique {

--- a/src/Resources/CoreErrorMessages.resx
+++ b/src/Resources/CoreErrorMessages.resx
@@ -120,6 +120,9 @@
   <data name="DbLookupFailureMessage" xml:space="preserve">
     <value>Database query lookup failed; the query returned {0} matching records</value>
   </data>
+  <data name="DbSourceColumnMissing" xml:space="preserve">
+    <value>Column name not found in database query results</value>
+  </data>
   <data name="DbUpsertKeyNotUnique" xml:space="preserve">
     <value>Database upsert failed; the key parameter values are not unique</value>
   </data>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -37,9 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="FluentValidation" Version="9.2.0" />
+    <PackageReference Include="FluentValidation" Version="9.3.0" />
     <PackageReference Include="Identifiable" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-rc.2.20475.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-preview.4.6</Version>
+    <Version>1.0.0-rc.1.0</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.0</Version>
+    <Version>1.0.0-rc.1.1</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/test/Dataflows/Sources/DbSourceTests/HandlerTests.cs
+++ b/test/Dataflows/Sources/DbSourceTests/HandlerTests.cs
@@ -1,0 +1,60 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using Shipwright.Databases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Shipwright.Dataflows.Sources.DbSource;
+
+namespace Shipwright.Dataflows.Sources.DbSourceTests
+{
+    public class HandlerTests
+    {
+        IDbConnectionDispatcher connectionDispatcher;
+        ISourceHandler<DbSource> instance() => new Handler( connectionDispatcher );
+
+        Mock<IDbConnectionDispatcher> mockConnectionDispatcher;
+
+        public HandlerTests()
+        {
+            mockConnectionDispatcher = Mockery.Of( out connectionDispatcher );
+        }
+
+        public class Constructor : HandlerTests
+        {
+            [Fact]
+            public void requires_connectionDispatcher()
+            {
+                connectionDispatcher = null!;
+                Assert.Throws<ArgumentNullException>( nameof( connectionDispatcher ), instance );
+            }
+        }
+
+        public class Read : HandlerTests
+        {
+            DbSource source = new DbSource();
+            Dataflow dataflow = new Dataflow();
+            async Task<List<Record>> method() => await instance().Read( source, dataflow, default ).ToListAsync();
+
+            [Fact]
+            public async Task requires_source()
+            {
+                source = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( source ), method );
+            }
+
+            [Fact]
+            public async Task requires_dataflow()
+            {
+                dataflow = null!;
+                await Assert.ThrowsAsync<ArgumentNullException>( nameof( dataflow ), method );
+            }
+        }
+    }
+}

--- a/test/Dataflows/Sources/DbSourceTests/ValidatorTests.cs
+++ b/test/Dataflows/Sources/DbSourceTests/ValidatorTests.cs
@@ -1,0 +1,59 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using AutoFixture.Xunit2;
+using FluentValidation;
+using Shipwright.Databases;
+using System.Collections.Generic;
+using Xunit;
+using static Shipwright.Dataflows.Sources.DbSource;
+
+namespace Shipwright.Dataflows.Sources.DbSourceTests
+{
+    public class ValidatorTests
+    {
+        private readonly IValidator<DbSource> validator = new Validator();
+        private readonly Fixture fixture = new Fixture();
+
+        public class ConnectionInfo : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.ConnectionInfo, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.ConnectionInfo, new FakeConnectionInfo() );
+        }
+
+        public class Output : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Output, null );
+
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_any_field_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (value, fixture.Create<string>()) } );
+
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_any_column_null_or_whitespace( string value ) =>
+                validator.InvalidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) { (fixture.Create<string>(), value) } );
+
+            [Fact]
+            public void valid_when_empty() => validator.ValidWhen( _ => _.Output, new List<(string, string)>() );
+
+            [Fact]
+            public void valid_when_all_elements_given() => validator.ValidWhen( _ => _.Output, new List<(string, string)>( fixture.CreateMany<(string, string)>() ) );
+        }
+
+        public class Sql : ValidatorTests
+        {
+            [Theory, Cases.NullAndWhiteSpace]
+            public void invalid_when_null_or_whitespace( string value ) => validator.InvalidWhen( _ => _.Sql, value );
+
+            [Theory, AutoData]
+            public void valid_when_given( string value ) => validator.ValidWhen( _ => _.Sql, value );
+        }
+    }
+}

--- a/test/Shipwright.Core.Test.csproj
+++ b/test/Shipwright.Core.Test.csproj
@@ -10,9 +10,9 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200921-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="Moq" Version="4.14.7" />
-    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1343
---
### Problem
As an ETL developer, I want to be able to use a database query as a dataflow record source.

### Solution
Added DbSource that allows executing a parameterized query  and returns the results as a dataflow record stream. This will map column values to specified field names.

### Additional Notes
Promoted to RC.1.0 since .NET 5 is now GA