### PR TITLE
DATA-9567: Add description to data source

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.1</Version>
+    <Version>1.0.0-rc.1.2</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Dataflows/Sources/Source.cs
+++ b/src/Dataflows/Sources/Source.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 TTCO Holding Company, Inc. and Contributors
 // Licensed under the Apache License, Version 2.0
 // See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
@@ -11,5 +11,13 @@ namespace Shipwright.Dataflows.Sources
     /// Defines a dataflow record source.
     /// </summary>
 
-    public abstract record Source : IRequiresValidation { }
+    public abstract record Source : IRequiresValidation
+    {
+        /// <summary>
+        /// Description to use for the data source.
+        /// This value can be used for logging.
+        /// </summary>
+
+        public string? Description { get; init; }
+    }
 }

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.1</Version>
+    <Version>1.0.0-rc.1.2</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/DATA-9567
---
### Problem
As a developer, I want to use an optional description for data sources that can be used for logging. It was discovered that the built-in ToString method on records will serialize the entire entity, potentially containing sensitive information or detail.

### Solution
Added a simple description property.