### PR TITLE
NET-1488: Optional mapping for DbSource output

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.2</Version>
+    <Version>1.0.0-rc.1.3</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.2</Version>
+    <Version>1.0.0-rc.1.3</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1488
---
### Problem
As an ETL developer, I want output mappings for DbSource to be optional so that I do not have to explicitly map every field and column when all columns are being mapped to fields of the same name.

### Solution
Added a check to output columns directly as fields when no output mappings are present.