### PR TITLE
NET-1511: Fix defect where transformation decorators are not disposing handlers

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,13 +7,13 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.4</Version>
+    <Version>1.0.0-rc.1.5</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>
     <Description>Core components of the Shipwright Extract-Transform-Load (ETL) toolset using Lamar IoC.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/seaseducation/Shipwright.Core</RepositoryUrl>
+    <RepositoryUrl>https://github.com/seaseducation/Shipwright.Core.git</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin/Shipwright.Core.Lamar.xml</DocumentationFile>
     <PackageReleaseNotes>See https://github.com/seaseducation/Shipwright.Core/releases</PackageReleaseNotes>

--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.3</Version>
+    <Version>1.0.0-rc.1.4</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Dataflows/Transformations/Internal/EventInspectionHandlerDecorator.cs
+++ b/src/Dataflows/Transformations/Internal/EventInspectionHandlerDecorator.cs
@@ -27,6 +27,12 @@ namespace Shipwright.Dataflows.Transformations.Internal
         }
 
         /// <summary>
+        /// Implementation of <see cref="IAsyncDisposable"/>.
+        /// </summary>
+
+        protected override ValueTask DisposeAsyncCore() => inner.DisposeAsync();
+
+        /// <summary>
         /// Inspects a record's events and skips processing when a fatal event is found.
         /// </summary>
 

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.3</Version>
+    <Version>1.0.0-rc.1.4</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,13 +7,13 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.4</Version>
+    <Version>1.0.0-rc.1.5</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>
     <Description>Core components of the Shipwright Extract-Transform-Load (ETL) toolset.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/seaseducation/Shipwright.Core</RepositoryUrl>
+    <RepositoryUrl>https://github.com/seaseducation/Shipwright.Core.git</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin/Shipwright.Core.xml</DocumentationFile>
     <PackageReleaseNotes>See https://github.com/seaseducation/Shipwright.Core/releases</PackageReleaseNotes>

--- a/test/Dataflows/Transformations/Internal/CancellationHandlerDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/CancellationHandlerDecoratorTests.cs
@@ -72,7 +72,7 @@ namespace Shipwright.Dataflows.Transformations.Internal
             private ValueTask method() => instance().DisposeAsync();
 
             [Fact]
-            public async ValueTask disposes_inner_handler()
+            public async Task disposes_inner_handler()
             {
                 mockInner.Setup( _ => _.DisposeAsync() ).Returns( ValueTask.CompletedTask );
 

--- a/test/Dataflows/Transformations/Internal/EventInspectionFactoryDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/EventInspectionFactoryDecoratorTests.cs
@@ -41,7 +41,7 @@ namespace Shipwright.Dataflows.Transformations.Internal
             private Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
 
             [Fact]
-            public async ValueTask requires_transformation()
+            public async Task requires_transformation()
             {
                 transformation = null!;
                 await Assert.ThrowsAsync<ArgumentNullException>( nameof( transformation ), method );

--- a/test/Dataflows/Transformations/Internal/EventInspectionHandlerDecoratorTests.cs
+++ b/test/Dataflows/Transformations/Internal/EventInspectionHandlerDecoratorTests.cs
@@ -42,7 +42,7 @@ namespace Shipwright.Dataflows.Transformations.Internal
             private Task method() => instance().Transform( record, cancellationToken );
 
             [Fact]
-            public async ValueTask requires_record()
+            public async Task requires_record()
             {
                 record = null!;
                 await Assert.ThrowsAsync<ArgumentNullException>( nameof( record ), method );
@@ -50,7 +50,7 @@ namespace Shipwright.Dataflows.Transformations.Internal
 
             [Theory]
             [ClassData( typeof( Cases.BooleanCases ) )]
-            public async ValueTask skips_inner_when_fatal_event( bool canceled )
+            public async Task skips_inner_when_fatal_event( bool canceled )
             {
                 cancellationToken = new CancellationToken( canceled );
 
@@ -69,9 +69,8 @@ namespace Shipwright.Dataflows.Transformations.Internal
                 mockInner.Verify( _ => _.Transform( record, cancellationToken ), Times.Never() );
             }
 
-            [Theory]
-            [ClassData( typeof( Cases.BooleanCases ) )]
-            public async ValueTask calls_inner_when_no_fatal_events( bool canceled )
+            [Theory, Cases.BooleanCases]
+            public async Task calls_inner_when_no_fatal_events( bool canceled )
             {
                 cancellationToken = new CancellationToken( canceled );
 
@@ -97,9 +96,9 @@ namespace Shipwright.Dataflows.Transformations.Internal
             private ValueTask method() => instance().DisposeAsync();
 
             [Fact]
-            public async ValueTask disposes_inner_handler()
+            public async Task disposes_inner_handler()
             {
-                mockInner.Setup( _ => _.DisposeAsync() ).Returns( ValueTask.CompletedTask );
+                mockInner.Setup( _ => _.DisposeAsync() ).Returns( ValueTask.CompletedTask ).Verifiable();
 
                 await method();
                 mockInner.Verify( _ => _.DisposeAsync(), Times.Once() );

--- a/test/Shipwright.Core.Test.csproj
+++ b/test/Shipwright.Core.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.14.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1511
---
### Problem
While working on logging, I discovered that CSV output files generated by a dataflow could not be compressed because the file was in use.

### Solution
I tracked the issue down to a transformation decorator not disposing of its decorated handler. I was able to quickly add the missing dispose.

### Additional Notes
I had a test that should have caught this, but the test had a flaw: I had mistakenly made the unit test return `ValueTask` instead of `Task`. XUnit does not understand `ValueTask` and report all such test as passing, even when they fail.

I located all the tests returning `ValueTask` and corrected them to `Task`.