### PR TITLE
NET-1518: Add callback for database sources during reading for resource cleanup

### DIFF
--- a/lamar/src/Shipwright.Core.Lamar.csproj
+++ b/lamar/src/Shipwright.Core.Lamar.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.5</Version>
+    <Version>1.0.0-rc.1.6</Version>
     <PackageId>Shipwright.Core.Lamar</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>

--- a/src/Databases/IDbConnectionFactory.cs
+++ b/src/Databases/IDbConnectionFactory.cs
@@ -19,5 +19,16 @@ namespace Shipwright.Databases
         /// <returns>A database connection.</returns>
 
         IDbConnection Create();
+
+        /// <summary>
+        /// Called when the data source has completed reading from the current record.
+        /// This can be used to perform any post-processing of data values specific to the database provider.
+        /// </summary>
+        /// <param name="reader">Data reader at the current record position.</param>
+        /// <remarks>
+        /// This was added as a callback due to a memory leak when reading blob/clob data from Oracle.
+        /// </remarks>
+
+        void FinishReadingCurrentRecord( IDataReader reader ) { }
     }
 }

--- a/src/Dataflows/Sources/DbSource.Handler.cs
+++ b/src/Dataflows/Sources/DbSource.Handler.cs
@@ -110,6 +110,9 @@ namespace Shipwright.Dataflows.Sources
                         extractByColumn( reader, data );
                     }
 
+                    // perform any provider-specific operations on the reader
+                    connectionFactory.FinishReadingCurrentRecord( reader );
+
                     return new Record( dataflow, source, data, ++position );
                 }
 

--- a/src/Shipwright.Core.csproj
+++ b/src/Shipwright.Core.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet package info -->
-    <Version>1.0.0-rc.1.5</Version>
+    <Version>1.0.0-rc.1.6</Version>
     <PackageId>Shipwright.Core</PackageId>
     <Authors>TTCO Holding Company Inc. and Contributors</Authors>
     <Copyright>Copyright 2020 TTCO Holding Company Inc. and Contributors</Copyright>


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1518
---
### Problem
When DbSource reads data from an Oracle data reader containing blob/clob fields, these fields contain disposable types that are not properly disposed when the reader advances to the next record. 

### Solution
Added an optional callback method on provider-specific connection factory implementations that can be called when reading a record is finished so that cleanup can be performed on any record-specific resources.
