### PR TITLE
NET-1617: Callbacks for DbUpsert on insert/update/unchanged

### DIFF
--- a/Core/src/Dataflows/Transformations/DbUpsert.Handler.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.Handler.cs
@@ -283,11 +283,18 @@ namespace Shipwright.Dataflows.Transformations
                         {
                             var insert = BuildInsertSql( record, out var parameters );
                             await Execute( insert, parameters, cancellationToken );
+                            await transformation.OnInserted( record, cancellationToken );
                         }
 
                         else if ( ShouldUpdate( record, current, out var update, out var parameters ) )
                         {
                             await Execute( update, parameters, cancellationToken );
+                            await transformation.OnUpdated( record, cancellationToken );
+                        }
+
+                        else
+                        {
+                            await transformation.OnUnchanged( record, cancellationToken );
                         }
                     }
                 }

--- a/Core/src/Dataflows/Transformations/DbUpsert.Validator.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.Validator.cs
@@ -62,6 +62,9 @@ namespace Shipwright.Dataflows.Transformations
                 RuleFor( _ => _.Table ).NotNull().NotWhiteSpace();
                 RuleFor( _ => _.SqlHelper ).NotNull();
                 RuleFor( _ => _.DuplicateKeyEventMessage ).NotNull();
+                RuleFor( _ => _.OnInserted ).NotNull();
+                RuleFor( _ => _.OnUnchanged ).NotNull();
+                RuleFor( _ => _.OnUpdated ).NotNull();
             }
         }
     }

--- a/Core/src/Dataflows/Transformations/DbUpsert.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.cs
@@ -5,6 +5,8 @@
 
 using Shipwright.Databases;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Shipwright.Dataflows.Transformations
 {
@@ -37,6 +39,32 @@ namespace Shipwright.Dataflows.Transformations
         /// </summary>
 
         public ICollection<Mapping> Mappings { get; init; } = new List<Mapping>();
+
+        /// <summary>
+        /// Defines a delegate for executing code against a dataflow record.
+        /// </summary>
+        /// <param name="record">The dataflow record being transformed.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+
+        public delegate Task NotificationDelegate( Record record, CancellationToken cancellationToken );
+
+        /// <summary>
+        /// Delegate to execute only after a record is inserted.
+        /// </summary>
+
+        public NotificationDelegate OnInserted { get; init; } = ( record, ct ) => Task.CompletedTask;
+
+        /// <summary>
+        /// Delegate to execute only after a record is updated.
+        /// </summary>
+
+        public NotificationDelegate OnUpdated { get; init; } = ( record, ct ) => Task.CompletedTask;
+
+        /// <summary>
+        /// Delegate to execute only when the record is unchanged.
+        /// </summary>
+
+        public NotificationDelegate OnUnchanged { get; init; } = ( record, ct ) => Task.CompletedTask;
 
         /// <summary>
         /// Defines a delegate for generating an event message for when duplicate keys are detected.

--- a/Core/test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/Core/test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -10,6 +10,7 @@ using Shipwright.Databases;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using static Shipwright.Dataflows.Transformations.DbUpsert;
 
@@ -90,6 +91,33 @@ namespace Shipwright.Dataflows.Transformations.DbUpsertTests
 
             [Fact]
             public void valid_when_given() => validator.ValidWhen( _ => _.DuplicateKeyEventMessage, count => $"{count}" );
+        }
+
+        public class OnInserted : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.OnInserted, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.OnInserted, ( r, ct ) => Task.CompletedTask );
+        }
+
+        public class OnUnchanged : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.OnUnchanged, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.OnUnchanged, ( r, ct ) => Task.CompletedTask );
+        }
+
+        public class OnUpdated : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.OnUpdated, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.OnUpdated, ( r, ct ) => Task.CompletedTask );
         }
     }
 }


### PR DESCRIPTION
### Problem
As an ETL developer, I want to execute a callback when a record is processed by the `DbUpsert` transformation that I can use to perform an action upon conclusion of each state, such as setting a record value that indicates that an action was taken.

### Solution
Added callback delegates to the DbUpsert transformation that are executed in the appropriate condition.