### PR TITLE
NET-1629: DbUpsert fine-grained comparer for update logic

### DIFF
--- a/Core/src/Dataflows/Transformations/DbUpsert.Mapping.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.Mapping.cs
@@ -10,9 +10,18 @@ namespace Shipwright.Dataflows.Transformations
     public partial record DbUpsert
     {
         /// <summary>
+        /// Delegate for comparing values to determine whether the target should be updated.
+        /// </summary>
+        /// <param name="incoming">Source value from the dataflow.</param>
+        /// <param name="existing">Target value from the database.</param>
+        /// <returns>True when the column should be updated, otherwise false.</returns>
+
+        public delegate bool ShouldUpdateComparer( object? incoming, object? existing );
+
+        /// <summary>
         /// Declares a mapping between a record field and a database column.
         /// </summary>
 
-        public record Mapping( string Field, string Column, ColumnType Type );
+        public record Mapping( string Field, string Column, ColumnType Type, ShouldUpdateComparer? Comparer = null );
     }
 }

--- a/Core/src/Dataflows/Transformations/DbUpsert.Validator.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.Validator.cs
@@ -27,7 +27,7 @@ namespace Shipwright.Dataflows.Transformations
                 {
                     if ( mappings != null )
                     {
-                        foreach ( var (field, column, type) in mappings )
+                        foreach ( var (field, column, type, comparer) in mappings )
                         {
                             if ( string.IsNullOrWhiteSpace( field ) || string.IsNullOrWhiteSpace( column ) )
                             {
@@ -44,7 +44,7 @@ namespace Shipwright.Dataflows.Transformations
                 {
                     if ( mappings != null )
                     {
-                        foreach ( var (field, column, type) in mappings )
+                        foreach ( var (field, column, type, comparer) in mappings )
                         {
                             if ( type == ColumnType.Key )
                             {


### PR DESCRIPTION
### Problem
As an ETL developer, I want to specify additional logic for updating fields in the DbUpsert transformation so that I can avoid updating in certain situations (e.g., when the target value is non-null or when the incoming value is null).

### Solution
Added a delegate comparer to the mapping that takes both the incoming and target values for determining whether to go ahead with the update.