### PR TITLE
NET-1589: Conversion performance improvements

### DIFF
--- a/Core/src/Dataflows/Transformations/Conversion.Converters.cs
+++ b/Core/src/Dataflows/Transformations/Conversion.Converters.cs
@@ -56,7 +56,7 @@ namespace Shipwright.Dataflows.Transformations
             /// Validator for email addresses.
             /// </summary>
 
-            public static ConverterDelegate Email { get; } = delegate ( object value, out object? result )
+            public static bool Email( object value, out object? result )
             {
                 if ( value is string text && emailValidator.IsValid( text ) )
                 {
@@ -76,21 +76,30 @@ namespace Shipwright.Dataflows.Transformations
 
                 result = null;
                 return false;
-            };
+            }
 
             /// <summary>
             /// Basic boolean converter.
             /// </summary>
 
-            public static ConverterDelegate Boolean { get; } = delegate ( object value, out object? result )
+            public static bool Boolean( object value, out object? result )
             {
-                if ( value is bool converted || (value is string text && bool.TryParse( text, out converted )) )
+                if ( value is bool converted )
                 {
                     result = converted;
                     return true;
                 }
 
-                if ( value is IConvertible convertible )
+                else if ( value is string text )
+                {
+                    if ( bool.TryParse( text, out converted ) )
+                    {
+                        result = converted;
+                        return true;
+                    }
+                }
+
+                else if ( value is IConvertible convertible )
                 {
                     try
                     {
@@ -103,48 +112,46 @@ namespace Shipwright.Dataflows.Transformations
 
                 result = null;
                 return false;
-            };
+            }
 
             /// <summary>
             /// Date converter that yields a <see cref="DateTime"/> value with no time component.
             /// </summary>
 
-            public static ConverterDelegate Date { get; } = delegate ( object value, out object? result )
+            public static bool Date( object value, out object? result )
             {
-                if ( value is DateTime converted || (value is string text && System.DateTime.TryParse( text, out converted )) )
+                if ( DateTime( value, out result ) && result is DateTime converted )
                 {
                     result = converted.Date;
                     return true;
                 }
 
-                if ( value is IConvertible convertible )
-                {
-                    try
-                    {
-                        result = Convert.ToDateTime( convertible ).Date;
-                        return true;
-                    }
-
-                    catch { }
-                }
-
                 result = null;
                 return false;
-            };
+            }
 
             /// <summary>
             /// Date and time converter that yields a <see cref="DateTime"/>.
             /// </summary>
 
-            public static ConverterDelegate DateTime { get; } = delegate ( object value, out object? result )
+            public static bool DateTime( object value, out object? result )
             {
-                if ( value is DateTime converted || (value is string text && System.DateTime.TryParse( text, out converted )) )
+                if ( value is DateTime converted )
                 {
                     result = converted;
                     return true;
                 }
 
-                if ( value is IConvertible convertible )
+                else if ( value is string text )
+                {
+                    if ( System.DateTime.TryParse( text, out converted ) )
+                    {
+                        result = converted;
+                        return true;
+                    }
+                }
+
+                else if ( value is IConvertible convertible )
                 {
                     try
                     {
@@ -157,7 +164,7 @@ namespace Shipwright.Dataflows.Transformations
 
                 result = null;
                 return false;
-            };
+            }
 
             /// <summary>
             /// Creates a converter for decimal values.

--- a/Core/test/Dataflows/Transformations/ConversionTests/ConverterTests/BooleanTests.cs
+++ b/Core/test/Dataflows/Transformations/ConversionTests/ConverterTests/BooleanTests.cs
@@ -13,7 +13,7 @@ namespace Shipwright.Dataflows.Transformations.ConversionTests.ConverterTests
     {
         private object value;
         private object result;
-        private bool method() => Converters.Boolean.Invoke( value, out result );
+        private bool method() => Converters.Boolean( value, out result );
 
         public class ConvertibleCases : TheoryData<object, bool>
         {

--- a/Core/test/Dataflows/Transformations/ConversionTests/ConverterTests/EmailTests.cs
+++ b/Core/test/Dataflows/Transformations/ConversionTests/ConverterTests/EmailTests.cs
@@ -14,7 +14,7 @@ namespace Shipwright.Dataflows.Transformations.ConversionTests.ConverterTests
     {
         private object value;
         private object result;
-        private bool method() => Converters.Email.Invoke( value, out result );
+        private bool method() => Converters.Email( value, out result );
 
         [Theory]
         [InlineData( long.MaxValue )]


### PR DESCRIPTION
### Problem
As a developer, I want to optimize the performance of converters to reduce the CPU cost of using the transformation. During testing of a dataflow with several conversion transformations, the process was using excessive amounts of CPU and dataflows were stalling without error.

### Solution
Better short-circuiting and avoiding the IConvertible cast when we already know the value is a string. This reduced the CPU cost dramatically and allowed conversion-heavy dataflows to execute much faster.