### PR TITLE
NET-1589: Fix stalled dataflow on unhandled exceptions

### DIFF
--- a/Core/src/Dataflows/Dataflow.Handler.cs
+++ b/Core/src/Dataflows/Dataflow.Handler.cs
@@ -88,8 +88,19 @@ namespace Shipwright.Dataflows
                 var buffer = new BufferBlock<Record>( blockOptions );
                 var action = new ActionBlock<Record>( async record =>
                 {
-                    await handler.Transform( record, cancellationToken );
-                    await NotifyRecordCompleted( record, cancellationToken );
+                    try
+                    {
+                        await handler.Transform( record, cancellationToken );
+                        await NotifyRecordCompleted( record, cancellationToken );
+                    }
+
+                    // complete on unhandled exceptions
+                    catch
+                    {
+                        buffer.Complete();
+                        throw;
+                    }
+
                 }, blockOptions );
 
                 // links the buffer block to the action block for automatic record transfer


### PR DESCRIPTION
### Problem
When a transformation encounters an unhandled exception, completion is not propagated to the dataflow block and the process will stall.

### Solution
Modified the delegate that executes transformations to complete the buffer, which causes the exception to terminate the process as expected.