### PR TITLE
NET-1591: DbUpsert handling of Oracle NUMBER

### DIFF
--- a/Core/src/Dataflows/Transformations/Conversion.Converters.cs
+++ b/Core/src/Dataflows/Transformations/Conversion.Converters.cs
@@ -25,13 +25,22 @@ namespace Shipwright.Dataflows.Transformations
             {
                 cultureInfo ??= CultureInfo.CurrentCulture;
 
-                if ( value is int converted || (value is string text && int.TryParse( text, styles, cultureInfo, out converted )) )
+                if ( value is int converted )
                 {
                     result = converted;
                     return true;
                 }
 
-                if ( value is IConvertible convertible )
+                else if ( value is string text )
+                {
+                    if ( int.TryParse( text, styles, cultureInfo, out converted ) )
+                    {
+                        result = converted;
+                        return true;
+                    }
+                }
+
+                else if ( value is IConvertible convertible )
                 {
                     try
                     {
@@ -174,13 +183,22 @@ namespace Shipwright.Dataflows.Transformations
             {
                 cultureInfo ??= CultureInfo.CurrentCulture;
 
-                if ( value is decimal converted || (value is string text && decimal.TryParse( text, styles, cultureInfo, out converted )) )
+                if ( value is decimal converted )
                 {
                     result = converted;
                     return true;
                 }
 
-                if ( value is IConvertible convertible )
+                else if ( value is string text )
+                {
+                    if ( decimal.TryParse( text, styles, cultureInfo, out converted ) )
+                    {
+                        result = converted;
+                        return true;
+                    }
+                }
+
+                else if ( value is IConvertible convertible )
                 {
                     try
                     {

--- a/Core/src/Dataflows/Transformations/DbUpsert.Handler.cs
+++ b/Core/src/Dataflows/Transformations/DbUpsert.Handler.cs
@@ -210,6 +210,13 @@ namespace Shipwright.Dataflows.Transformations
                     return (boolSource && intComparer == 1) || (!boolSource && intComparer == 0);
                 }
 
+                // handle decimal/numeric conversions
+                // this handles edge cases (specific to oracle) where dapper reads a numeric value into an unexpected data type
+                if ( source is decimal decimalSource && comparer is IConvertible convertible )
+                {
+                    return decimalSource.Equals( Convert.ToDecimal( convertible ) );
+                }
+
                 // handle typical comparisons
                 return Equals( source, comparer );
             }
@@ -250,8 +257,8 @@ namespace Shipwright.Dataflows.Transformations
                     {
                         var incoming = extract( field, column );
                         var existing = current.TryGetValue( column, out var value ) ? value : null!;
-                        
-                        if ( !IsEqual( incoming.Value, existing ) && ( comparer?.Invoke( incoming.Value, existing ) ?? true ) )
+
+                        if ( !IsEqual( incoming.Value, existing ) && (comparer?.Invoke( incoming.Value, existing ) ?? true) )
                         {
                             updates[column] = map[column] = incoming;
                         }

--- a/Core/test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
+++ b/Core/test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
@@ -80,6 +80,11 @@ namespace Shipwright.Dataflows.Transformations.DbUpsertTests
                     record.Data[field] = current[parameter] = fixture.Create<string>();
                 }
 
+                // include a convertible equivalent decimal value
+                var val = fixture.Create<int>();
+                current[mappings[4].Column] = val;
+                record.Data[mappings[4].Field] = Convert.ToDecimal( val );
+
                 var keyMap = new List<ColumnValue>
                 {
                     new ColumnValue( mappings[0].Column, "p1", record.Data[mappings[0].Field] ),
@@ -130,6 +135,9 @@ namespace Shipwright.Dataflows.Transformations.DbUpsertTests
                     record.Data[field] = current[parameter] = fixture.Create<string>();
                 }
 
+                // include a differing decimal convertible value
+                current[mappings[4].Column] = 42;
+                
                 var keyMap = new List<ColumnValue>
                 {
                     new ColumnValue( mappings[0].Column, "p1", record.Data[mappings[0].Field] ),
@@ -140,7 +148,7 @@ namespace Shipwright.Dataflows.Transformations.DbUpsertTests
                 {
                     // only the changed columns should be included in an update
                     new ColumnValue( mappings[3].Column, "p3", record.Data[mappings[3].Field] = fixture.Create<string>() ),
-                    new ColumnValue( mappings[4].Column, "p4", record.Data[mappings[4].Field] = fixture.Create<string>() ),
+                    new ColumnValue( mappings[4].Column, "p4", record.Data[mappings[4].Field] = 43M ),
 
                     // trigger column should be included in any update, regardless of whether it has changed
                     new ColumnValue( mappings[6].Column, "p6", record.Data[mappings[6].Field] ),


### PR DESCRIPTION
### Problem
Dapper handles the `NUMBER` data type in Oracle inconsistently. While the behavior is predictable based on the column definition, it not documented and difficult for an ETL developer to know ahead of time.

### Solution
Assume:
- Decimal is the safest and most compatible data type corresponding to the Oracle `NUMBER` type.
- Any value coming into a DbUpsert transformation that has been coerced to a decimal should be compared as such.  When an incoming value has been coerced to a decimal, DbUpsert will check values from Dapper that are not decimals but that are `IConvertible` and will coerce that value to a decimal for comparison.

### Additional Info
Improved the performance handling of decimal and integer converters.