### PR TITLE
NET-1807: Additional parameters for DbLookup transformation

### DIFF
--- a/Core/src/Dataflows/Transformations/Conversion.FailureEventSettings.cs
+++ b/Core/src/Dataflows/Transformations/Conversion.FailureEventSettings.cs
@@ -41,7 +41,7 @@ namespace Shipwright.Dataflows.Transformations
             /// Defaults to true.
             /// </summary>
 
-            public bool ClearField = true;
+            public bool ClearField { get; init; } = true;
         }
     }
 }

--- a/Core/src/Dataflows/Transformations/DbLookup.Handler.cs
+++ b/Core/src/Dataflows/Transformations/DbLookup.Handler.cs
@@ -47,6 +47,14 @@ namespace Shipwright.Dataflows.Transformations
             {
                 var parameters = new Dictionary<string, object?>();
 
+                foreach ( var (name, value) in transformation.Parameters )
+                {
+                    if ( !string.IsNullOrWhiteSpace( name ) )
+                    {
+                        parameters[name] = value;
+                    }
+                }
+
                 foreach ( var (field, param) in transformation.Input )
                 {
                     parameters[param] = record.Data.TryGetValue( field, out var value )

--- a/Core/src/Dataflows/Transformations/DbLookup.Validator.cs
+++ b/Core/src/Dataflows/Transformations/DbLookup.Validator.cs
@@ -66,6 +66,7 @@ namespace Shipwright.Dataflows.Transformations
                 RuleFor( _ => _.ConnectionInfo ).NotNull();
                 RuleFor( _ => _.Input ).NotNull().Must( HaveDefinedValues );
                 RuleFor( _ => _.Output ).NotNull().Must( HaveDefinedValues );
+                RuleFor( _ => _.Parameters ).NotNull();
                 RuleFor( _ => _.QueryMultipleRecordEvent ).NotNull().SetValidator( new FailureEventSettingValidator() );
                 RuleFor( _ => _.QueryZeroRecordEvent ).NotNull().SetValidator( new FailureEventSettingValidator() );
                 RuleFor( _ => _.Sql ).NotNull().NotWhiteSpace();

--- a/Core/src/Dataflows/Transformations/DbLookup.cs
+++ b/Core/src/Dataflows/Transformations/DbLookup.cs
@@ -68,5 +68,11 @@ namespace Shipwright.Dataflows.Transformations
         /// </summary>
 
         public bool CacheResults { get; set; }
+
+        /// <summary>
+        /// Additional named values that can be added to the parameter input. 
+        /// </summary>
+
+        public ICollection<(string name, object value)> Parameters { get; init; } = new List<(string, object)>();
     }
 }

--- a/Core/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
+++ b/Core/test/Dataflows/Transformations/DbLookupTests/HandlerTests.cs
@@ -69,6 +69,15 @@ namespace Shipwright.Dataflows.Transformations.DbLookupTests
                 expected[third.parameter] = null;
                 transformation.Input.Add( third );
 
+                // add inline parameter
+                var fourth = fixture.Create<(string parameter, string value)>();
+                transformation.Parameters.Add( ( fourth.parameter, fourth.value ) );
+                expected[fourth.parameter] = fourth.value;
+
+                // add inline parameter that conflicts with a field name
+                // the input parameter should take its place
+                transformation.Parameters.Add( ( first.parameter, Guid.NewGuid() ) );
+
                 var actual = method();
                 actual.Should().BeEquivalentTo( expected );
             }

--- a/Core/test/Dataflows/Transformations/DbLookupTests/ValidatorTests.cs
+++ b/Core/test/Dataflows/Transformations/DbLookupTests/ValidatorTests.cs
@@ -93,5 +93,14 @@ namespace Shipwright.Dataflows.Transformations.DbLookupTests
             [Theory, AutoData]
             public void valid_when_given( string value ) => validator.ValidWhen( _ => _.Sql, value );
         }
+
+        public class Parameters : ValidatorTests
+        {
+            [Fact]
+            public void invalid_when_null() => validator.InvalidWhen( _ => _.Parameters, null );
+
+            [Fact]
+            public void valid_when_given() => validator.ValidWhen( _ => _.Parameters, new List<(string, object)>() );
+        }
     }
 }


### PR DESCRIPTION
### Problem
As a developer, I want to pass additional static input parameters to DbLookup transformations that are not part of the dataflow record so that I can add them as query parameters without needing to add static values to every record.

### Solution
Added a parameter collection to DbLookup that will be added to the input parameters collection for the query. In the event any parameter names conflict with Input column names, the value from the record will override the static parameter value.

### Additional Notes
Also corrected the ClearField field to a property on the Conversion transformation.