### PR TITLE
NET-1820: Update Oracle library

### DIFF
--- a/Oracle/src/Shipwright.Oracle.csproj
+++ b/Oracle/src/Shipwright.Oracle.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.100" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Problem
When running under VS 2022, Oracle components throw an exception due to a binary serializer that is not allowed to run due to security risks.

### Solution
Updated Oracle data components to the latest version.