### PR TITLE
NET-1616: Option to skip lines before reading CSV files

### DIFF
--- a/CsvHelper/src/Dataflows/Sources/CsvSource.Handler.cs
+++ b/CsvHelper/src/Dataflows/Sources/CsvSource.Handler.cs
@@ -61,6 +61,15 @@ namespace Shipwright.Dataflows.Sources
             private static async IAsyncEnumerable<Record> Read( CsvSource source, Dataflow dataflow )
             {
                 using var reader = File.OpenText( source.Path );
+
+                for ( var skip = 0; skip < source.SkipLines; skip++ )
+                {
+                    if ( !reader.EndOfStream )
+                    {
+                        await reader.ReadLineAsync();
+                    }
+                }
+
                 using var csv = new CsvReader( reader, source.Settings );
                 var headers = new Dictionary<int, string>();
 
@@ -85,7 +94,7 @@ namespace Shipwright.Dataflows.Sources
                         }
                     }
 
-                    yield return new Record( dataflow, source, data, csv.Context.Row );
+                    yield return new Record( dataflow, source, data, csv.Context.Row + source.SkipLines );
                 }
             }
 

--- a/CsvHelper/src/Dataflows/Sources/CsvSource.Validator.cs
+++ b/CsvHelper/src/Dataflows/Sources/CsvSource.Validator.cs
@@ -23,6 +23,7 @@ namespace Shipwright.Dataflows.Sources
             {
                 RuleFor( _ => _.Path ).NotNull().NotWhiteSpace();
                 RuleFor( _ => _.Settings ).NotNull();
+                RuleFor( _ => _.SkipLines ).GreaterThanOrEqualTo( 0 );
             }
         }
     }

--- a/CsvHelper/src/Dataflows/Sources/CsvSource.cs
+++ b/CsvHelper/src/Dataflows/Sources/CsvSource.cs
@@ -41,5 +41,14 @@ namespace Shipwright.Dataflows.Sources
         /// </summary>
 
         public bool ThrowOnBadData { get; init; } = true;
+
+        /// <summary>
+        /// Number of lines in the file to skip before starting CSV parsing.
+        /// Due to its nature, normal CSV parsing rules will not apply to the skipped lines.
+        /// This is intended for cases where header rows in files need to be ignored and not
+        /// even have their number of fields counted by CSV helper.
+        /// </summary>
+
+        public int SkipLines { get; init; } = 0;
     }
 }

--- a/CsvHelper/test/Dataflows/Sources/CsvSourceTests/ValidatorTests.cs
+++ b/CsvHelper/test/Dataflows/Sources/CsvSourceTests/ValidatorTests.cs
@@ -33,5 +33,19 @@ namespace Shipwright.Dataflows.Sources.CsvSourceTests
             [Fact]
             public void valid_when_given() => validator.ValidWhen( _ => _.Settings, new CsvConfiguration( CultureInfo.CurrentCulture ) );
         }
+
+        public class SkipLines : ValidatorTests
+        {
+            [Theory]
+            [InlineData( -1 )]
+            [InlineData( -2 )]
+            public void invalid_when_less_than_zero( int value ) => validator.InvalidWhen( _ => _.SkipLines, value );
+
+            [Theory]
+            [InlineData( 0 )]
+            [InlineData( 1 )]
+            [InlineData( 2 )]
+            public void valid_when_greater_or_equal_to_zero( int value ) => validator.ValidWhen( _ => _.SkipLines, value );
+        }
     }
 }


### PR DESCRIPTION
https://seaseducation.atlassian.net/browse/NET-1616
---
### Problem
As an ETL developer, I want an option to skip a number of rows at the beginning of a file before activating the CSV reader so that I can map fields by position when the records do not match the header row.

### Solution
Added a CSV source option that skips a specified number of lines.

### Additional Notes
The skipped lines are treated as pain text without any CSV parsing. The skipping function will count line breaks whether they are escaped or not.